### PR TITLE
LDAP Authorization

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,11 +8,15 @@ It is split into two components: authentication (who are you?) and
 authorization (what can you do?).
 
 Supported authentication systems:
- * Persona - A very basic verification that the user owns an email address
  * SSO - SAML via Okta, Mozilla, Inc.'s single-signon provider.  This service
    supplies multi-factor auth and a host of other benefits.  This expects a
    `taskcluster-email` property in the SAML assertion, giving the user's
-   LDAP email.
+   LDAP email.  User identities are of the form `mozilla-ldap/<email>`.
+ * LDAP - For users who cannot use Okta, this allows authentication using a
+   boring old username/password form, authenticated against Mozilla's LDAP.
+   User identities are of the form `mozilla-ldap/<email>`.
+ * Persona - A very basic verification that the user owns an email address.
+   User identities are of the form `persona/<email`.
 
 Supported authorization systems:
  * LDAP - Translates LDAP groups (including POSIX groups) to TaskCluster roles

--- a/assets/style.css
+++ b/assets/style.css
@@ -1,3 +1,30 @@
 #credentials dt, #credentials dd {
   padding-top: 5px;
 }
+
+.row.login-option {
+    padding-bottom: 1em;
+}
+
+#ldap-form .form-control {
+  position: relative;
+  height: auto;
+  -webkit-box-sizing: border-box;
+     -moz-box-sizing: border-box;
+          box-sizing: border-box;
+  padding: 10px;
+  font-size: 16px;
+}
+#ldap-form .form-control:focus {
+  z-index: 2;
+}
+#ldap-form input[type="email"] {
+  margin-bottom: -1px;
+  border-bottom-right-radius: 0;
+  border-bottom-left-radius: 0;
+}
+#ldap-form input[type="password"] {
+  margin-bottom: 10px;
+  border-top-left-radius: 0;
+  border-top-right-radius: 0;
+}

--- a/config.yml
+++ b/config.yml
@@ -3,6 +3,7 @@ Defaults:
     authenticators:
       - persona
       - sso
+      - ldap
     authorizers:
       - ldap
       - mozillians

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "lodash": "^3.10.1",
     "mozillians-client": "^0.1.1",
     "passport": "^0.3.0",
+    "passport-local": "^1.0.0",
     "passport-persona": "jonasfj/passport-persona",
     "passport-saml": "^0.13.0",
     "promise": "^7.0.4",

--- a/src/authn/ldap.js
+++ b/src/authn/ldap.js
@@ -1,0 +1,75 @@
+import express from 'express'
+import local from 'passport-local'
+import passport from 'passport'
+import assert from 'assert'
+import User from './../user'
+import LDAPClient from './../ldap';
+
+class LDAPLogin {
+  constructor(options) {
+    assert(options, 'options are required');
+    assert(options.cfg, 'options.cfg is required');
+    assert(options.cfg.ldap, 'options.cfg.ldap is required');
+    assert(options.cfg.ldap.url, 'options.cfg.ldap.url is required');
+    assert(options.cfg.ldap.cert, 'options.cfg.ldap.cert is required');
+    assert(options.cfg.ldap.key, 'options.cfg.ldap.key is required');
+    assert(options.authorize, 'options.authorize is required');
+
+    this.user = options.cfg.ldap.user;
+    this.password = options.cfg.ldap.password;
+    this.client = new LDAPClient(options.cfg.ldap);
+    this.authorize = options.authorize;
+
+    passport.use(new local.Strategy({
+      passReqToCallback: true,
+    }, (req, user, password, done) => {
+          this.localCallback(req, user, password)
+          .then((res) => done(null, res))
+          .catch((err) => {
+            console.log("Error authenticating local user", err.stack);
+            done(null, false, {message: err.message});
+          })
+        }));
+  }
+
+  router() {
+    let router = new express.Router();
+    router.post('/login', passport.authenticate('local', {
+      successRedirect: '/',
+      failureRedirect: '/',
+      failureFlash: true
+    }));
+    return router;
+  };
+
+  authFail() {
+    // we do not want to distinguish no-such-user from bad-password, lest this
+    // tool become an oracle for discovering valid usernames
+    throw new Error("User not found or incorrect password");
+  }
+
+  async localCallback(req, email, password) {
+    // bind as the bind user to convert email to DN
+    await this.client.bind(this.user, this.password);
+    let userDn = await this.client.dnForEmail(email);
+    if (!userDn) {
+      return this.authFail();
+    }
+
+    // re-bind as the DN, to validate the password
+    try {
+      await this.client.bind(userDn, password);
+    } catch(e) {
+      return this.authFail();
+    }
+
+    // success!
+    let user = User.get(req);
+    user.identity = 'mozilla-ldap/' + email;
+    await this.authorize(user);
+    console.log(user);
+    return user;
+  }
+}
+
+module.exports = LDAPLogin;

--- a/src/authn/ldap.js
+++ b/src/authn/ldap.js
@@ -50,8 +50,8 @@ class LDAPLogin {
 
   async localCallback(req, email, password) {
     // bind as the bind user to convert email to DN
-    await this.client.bind(this.user, this.password);
-    let userDn = await this.client.dnForEmail(email);
+    let userDn = await this.client.bind(this.user, this.password,
+        (client) => client.dnForEmail(email));
     if (!userDn) {
       return this.authFail();
     }
@@ -67,7 +67,6 @@ class LDAPLogin {
     let user = User.get(req);
     user.identity = 'mozilla-ldap/' + email;
     await this.authorize(user);
-    console.log(user);
     return user;
   }
 }

--- a/src/authn/persona.js
+++ b/src/authn/persona.js
@@ -33,7 +33,6 @@ class PersonaLogin {
   }
 
   async personaCallback(req, email, done) {
-    console.log("personalCallback", this);
     try {
       let user = User.get(req);
       user.identity = 'persona/' + email;

--- a/src/authn/sso.js
+++ b/src/authn/sso.js
@@ -36,11 +36,12 @@ class SSOLogin {
     return router;
   };
 
-  async samlCallback(req, profile, done) {
-    console.log(this.authorize);
+  samlCallback(req, profile, done) {
     try {
       let user = User.get(req);
-      user.identity = 'sso/' + profile['ldap-email'];
+      // note that we use the same identity prefix as the ldap authz as these
+      // currently have the same backend (Mozilla LDAP).
+      user.identity = 'mozilla-ldap/' + profile['ldap-email'];
       this.authorize(user, done);
     } catch (err) {
       done(err, null);

--- a/src/authz/ldap.js
+++ b/src/authz/ldap.js
@@ -58,7 +58,10 @@ class LDAPAuthorizer {
     // always perform a bind, in case the client has disconnected
     // since this connection was last used.
     await this.client.bind(this.user, this.password, async (client) => {
-      debug(`enumerating posix groups for ${email}`);
+      debug(`enumerating scm groups for ${email}`);
+      // SCM groups are posixGroup objects with the email in the memberUid
+      // field.  This code does not capture other POSIX groups (which have the
+      // user's uid field in the memberUid field).
       addRolesForEntries(await client.search(
         "dc=mozilla", {
         scope: 'sub',

--- a/src/ldap.js
+++ b/src/ldap.js
@@ -1,0 +1,69 @@
+var url = require('url');
+var ldap = require('ldapjs');
+var _ = require('lodash');
+var debug = require('debug')('LDAPClient');
+
+class LDAPClient {
+  constructor(cfg) {
+    let tlsOptions = {
+      cert:   cfg.cert,
+      key:    cfg.key,
+    };
+    let port = url.parse(cfg.url).port;
+    if (port) {
+      tlsOptions.port = port;
+    }
+
+    this.client = ldap.createClient({
+      url: cfg.url,
+      tlsOptions,
+      timeout: 10 * 1000,
+      reconnect: true,
+    });
+  }
+
+  bind(user, password) {
+    debug(`bind(${user}, <password>)`);
+    return new Promise((accept, reject) => this.client.bind(
+      user, password, err => {
+      err ? reject(err) : accept();
+    }));
+  }
+
+  search(base, options) {
+    debug(`search(${base}, ${JSON.stringify(options)})`);
+    return new Promise((accept, reject) => this.client.search(
+      base, options, (err, res) => {
+      err ? reject(err) : accept(res);
+    }));
+  }
+
+  dnForEmail(email) {
+    debug(`dnForEmail(${email})`);
+    let userDn;
+    return this.search(
+      "dc=mozilla", {
+      scope: 'sub',
+      filter: '(&(objectClass=inetOrgPerson)(mail=' + email + '))',
+      attributes: [],
+      timeLimit: 10,
+    }).then((res) => {
+      return new Promise((accept, reject) => {
+        res.on('searchEntry', entry => {
+          userDn = entry.object.dn;
+        });
+        res.on('error', (err) => {
+          reject(err);
+        });
+        res.on('end', result => {
+          if (result.status !== 0) {
+            return reject(new Error('LDAP error, got status: ' + result.status));
+          }
+          return accept(userDn);
+        });
+      });
+    });
+  }
+}
+
+module.exports = LDAPClient;

--- a/src/ldap.js
+++ b/src/ldap.js
@@ -46,7 +46,7 @@ class LDAPClient {
         }
       // carefully send errors to the caller while leaving the lock
       // Promise resolved
-      }).then((res) => accept(res)).catch(err => reject(err))
+      }).then(accept, reject)
     })
   }
 

--- a/views/index.jade
+++ b/views/index.jade
@@ -2,10 +2,7 @@ doctype html
 html(lang='en')
   head
     meta(charset='utf-8')
-    if title
-      title TaskCluster - Authentication
-    else
-      title TaskCluster - Authentication
+    title TaskCluster Login
     meta(name='viewport', content='width=device-width, initial-scale=1.0')
 
     // Bootstrap
@@ -33,14 +30,35 @@ html(lang='en')
     // Script with various hacks for this page
     script(src='/assets/script.js')
   body.container
+    div.modal#ldap-modal(tabindex="-1", role="dialog")
+      div.modal-dialog.modal-open
+        div.modal-content
+          form(action='/ldap/login', method='post')
+            div.modal-header
+              button.close(type="button", data-dismiss="modal" aria-label="Close")
+                span(aria-hidden="true") &times
+              h4.modal-title Mozilla LDAP Sign-In
+            div.modal-body#ldap-form
+              label.sr-only(for="username") LDAP Email
+              input.form-control#username(name="username", type="email",
+                                          placeholder="LDAP Email", required)
+              label.sr-only(for="password") Password
+              input.form-control#password(name="password", type="password",
+                                          placeholder="Password", required)
+            div.modal-footer
+              button.btn.btn-default(data-dismiss="modal", type="button") Close
+              button.btn.btn-primary(type='submit')
+                i.glyphicon.glyphicon-circle-arrow-right
+                | &nbsp;Sign-in
+
     div.row
       div.col-md-10.col-md-offset-1#content
-        h1 TaskCluster Authentication
+        h1 TaskCluster Login
         hr
         div.row.login-option
           div.col-md-4
             form(action='/sso/login', method='post')
-              button.btn.btn-primary(type='submit')
+              button.btn.btn-block.btn-primary(type='submit')
                 i.glyphicon.glyphicon-log-in
                 | &nbsp;Sign-in with Okta
           div.col-md-8
@@ -50,17 +68,9 @@ html(lang='en')
               | Okta email is included in your Mozillians profile.
         div.row.login-option
           div.col-md-4
-            form#ldap-form(action='/ldap/login', method='post')
-              label.sr-only(for="username") LDAP Email
-              input.form-control#username(name="username", type="email",
-                                          placeholder="LDAP Email", required)
-              label.sr-only(for="password") Password
-              input.form-control#password(name="password", type="password",
-                                          placeholder="Password", required)
-
-              button.btn.btn-primary(type='submit')
-                i.glyphicon.glyphicon-circle-arrow-right
-                | &nbsp;Sign-in with LDAP
+            button.btn.btn-block.btn-primary(data-toggle="modal", data-target="#ldap-modal")
+              i.glyphicon.glyphicon-circle-arrow-right
+              | &nbsp;Sign-in with LDAP
           div.col-md-8
             p
               | If you are not a Mozilla employee, but have an LDAP account granting
@@ -69,7 +79,7 @@ html(lang='en')
           div.col-md-4
             form#persona-form(action='/persona/login', method='post')
               input#persona-assertion(type='hidden', name='assertion')
-              button.btn.btn-primary#persona-signin(type='submit')
+              button.btn.btn-block.btn-primary#persona-signin(type='submit')
                 i.glyphicon.glyphicon-user
                 | &nbsp;Sign-in with Persona
           div.col-md-8

--- a/views/index.jade
+++ b/views/index.jade
@@ -37,7 +37,7 @@ html(lang='en')
       div.col-md-10.col-md-offset-1#content
         h1 TaskCluster Authentication
         hr
-        div.row
+        div.row.login-option
           div.col-md-4
             form(action='/sso/login', method='post')
               button.btn.btn-primary(type='submit')
@@ -48,16 +48,33 @@ html(lang='en')
               | If you are a Mozilla employee, sign in with Okta to maximize your
               | permissions.  If you also have a Mozillians account, make sure your
               | Okta email is included in your Mozillians profile.
-        div.row
+        div.row.login-option
+          div.col-md-4
+            form#ldap-form(action='/ldap/login', method='post')
+              label.sr-only(for="username") LDAP Email
+              input.form-control#username(name="username", type="email",
+                                          placeholder="LDAP Email", required)
+              label.sr-only(for="password") Password
+              input.form-control#password(name="password", type="password",
+                                          placeholder="Password", required)
+
+              button.btn.btn-primary(type='submit')
+                i.glyphicon.glyphicon-circle-arrow-right
+                | &nbsp;Sign-in with LDAP
+          div.col-md-8
+            p
+              | If you are not a Mozilla employee, but have an LDAP account granting
+              | you commit access, sign in with your LDAP username and password.
+        div.row.login-option
           div.col-md-4
             form#persona-form(action='/persona/login', method='post')
               input#persona-assertion(type='hidden', name='assertion')
               button.btn.btn-primary#persona-signin(type='submit')
-                i.glyphicon.glyphicon-log-in
-                | &nbsp;Sign-in with Mozillians
+                i.glyphicon.glyphicon-user
+                | &nbsp;Sign-in with Persona
           div.col-md-8
             p
-              | If you are a Mozillian but not an employee, sign in with Persona.
+              | If you are a Mozillian but do not have an LDAP account, sign in with Persona.
               | Your permissions will depend on the Mozillians groups you belong
               | to.  If you do not have a Mozillians profile,&nbsp;
               a(href='https://mozillians.org/en-US/')


### PR DESCRIPTION
Introduce a ("temporary") LDAP authentication mechanism

The idea is that users who cannot login vis SSO can use this (admittedly much less secure!) option to authenticate with their LDAP credentials, which are more closely associated with their development permissions.

This also factors out the LDAP client to be a little more promise-y.