### PR TITLE
Implement a scanner to disable clients

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,2 @@
-web: node lib/server.js $PROFILE
+web: node lib/server.js $PROFILE server
+scanner: node lib/server.js $PROFILE scanner

--- a/config.yml
+++ b/config.yml
@@ -12,6 +12,9 @@ Defaults:
       - localhost
       - tools.taskcluster.net
       - docs.taskcluster.net
+    credentials:
+      clientId:     !env TASKCLUSTER_CLIENT_ID
+      accessToken:  !env TASKCLUSTER_ACCESS_TOKEN
     temporaryCredentials:
       # Set the credentials to be valid 15 min before creation
       # (allowing for a bit of clock skew)
@@ -92,10 +95,26 @@ Profiles:
         credentials:
           clientId:     'dummy'
           accessToken:  'lol no secret here'
+      credentials:
+        clientId:     !env TASKCLUSTER_CLIENT_ID
+        accessToken:  !env TASKCLUSTER_ACCESS_TOKEN
     mozillians:
       allowedGroups: ['taskcluster-users']
     ldap:
-      allowedGroups: ['releng', 'shipit', 'Everyone', 'team_moco', 'shipitdev', 'scm_level_1', 'scm_level_2', 'scm_level_3']
+      allowedGroups: 
+      - 'releng'
+      - 'shipit'
+      - 'Everyone'
+      - 'team_moco'
+      - 'shipitdev'
+      - 'scm_level_1'
+      - 'scm_level_2'
+      - 'scm_level_3'
+      - 'vpn_tooltooleditor'
+      - 'team_relops'
+      - 'releng'
+      - 'team_taskcluster'
+      - 'ateam'
     sso:
       issuer: taskcluster-login.ngrok.io
       entryPoint: "https://mozilla.oktapreview.com/app/mozilla_taskcluster_1/exk58q0ytqJycvEJ10h7/sso/saml"

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "taskcluster-client": "^0.23.12",
     "taskcluster-lib-config": "^0.9.1",
     "taskcluster-lib-loader": "^0.1.1",
-    "taskcluster-lib-rules": "^1.0.3"
+    "taskcluster-lib-rules": "^1.0.3",
+    "taskcluster-lib-scopes": "^0.8.8"
   }
 }

--- a/src/authz/ldap.js
+++ b/src/authz/ldap.js
@@ -31,9 +31,14 @@ class LDAPAuthorizer {
     this.password = options.cfg.ldap.password;
     this.client = new LDAPClient(options.cfg.ldap);
     this.allowedGroups = options.cfg.ldap.allowedGroups;
+
+    this.identityProviders = ['mozilla-ldap'];
   }
 
   async setup() {
+  }
+
+  async rolesForUser(email) {
   }
 
   async authorize(user) {

--- a/src/authz/mozillians.js
+++ b/src/authz/mozillians.js
@@ -14,16 +14,15 @@ class MozilliansAuthorizer {
 
     this.mozillians = new Mozillians(options.cfg.mozillians.apiKey);
     this.allowedGroups = options.cfg.mozillians.allowedGroups;
+
+    // trust both persona and ldap-authenticated users
+    this.identityProviders = ['mozilla-ldap', 'persona'];
   }
 
   async setup() {
   }
 
   async authorize(user) {
-    // only trust persona- and sso-authenticated identities
-    if (user.identityProviderId !== "sso" && user.identityProviderId !== "persona") {
-      return;
-    }
     let email = user.identityId;
 
     debug(`mozilians authorizing ${user.identity}`);

--- a/src/scanner.js
+++ b/src/scanner.js
@@ -1,0 +1,69 @@
+import taskcluster from 'taskcluster-client'
+import scopeUtils from 'taskcluster-lib-scopes'
+import User from './user'
+import _ from 'lodash'
+var debug = require('debug')('scanner');
+
+export default async function scanner(cfg, authorizers) {
+  // * get the set of identityProviderIds
+  // * for each:
+  //   * fetch all clients, sort by identity
+  //   * for each identity:
+  //     * get roles from providers, expand
+  //     * for each client in that identity:
+  //       * get, verify client.expandedScopes satisfied by identity's expandedScopes
+
+  // NOTE: this function performs once auth operation at a time.  It is better
+  // for scans to take longer than for the auth service to be overloaded.
+  let auth = new taskcluster.Auth({credentials: cfg.app.credentials});
+
+  // gather all identityProviderIds used in any authorizer
+  let identityProviders = new Set(
+      authorizers.map(authz => authz.identityProviders).reduce((a,b) => a.concat(b)))
+
+  // enumerate all clients for any of those identity providers
+  let clients = [];
+  for (let idp of identityProviders) {
+    clients = clients.concat(await auth.listClients({prefix: idp + "/"}));
+  }
+
+  // sort by clientId, so that each identity (a prefix of the clientId) appears
+  // contiguously
+  clients = _.sortBy(clients, 'clientId');
+
+  // iterate through the clients, constructing a new User as necessary, comparing
+  // the client's scopes to the User's scopes and disabling where necessary.
+  let user, userScopes;
+  let idPattern = /^([^\/]*\/[^\/]*)\/.+$/
+  for (let client of clients.sort()) {
+    debug("examining client", client.clientId);
+    if (!client.clientId.match(idPattern) || client.disabled) {
+      continue;
+    }
+
+    // refresh the user if it does not correspond to this client
+    let clientIdentity = client.clientId.replace(idPattern, '$1');
+    if (!user || user.identity != clientIdentity) {
+      user = new User();
+      user.identity = clientIdentity;
+
+      await Promise.all(authorizers.map(authz => {
+        if (authz.identityProviders.indexOf(user.identityProviderId) !== -1) {
+          return authz.authorize(user)
+        }
+      }));
+
+      userScopes = (await auth.expandScopes({scopes: user.scopes()})).scopes;
+      // allow the implicit 'assume:client-id:<clientId> auth adds for each client
+      userScopes.push('assume:client-id:' + clientIdentity + '/*');
+
+      debug("..against user", user.identity);
+    }
+
+    // if this client's expandedScopes are not satisfied by the user's expanded
+    // scopes, disable the client.
+    if (!scopeUtils.scopeMatch(userScopes, [client.expandedScopes])) {
+      await auth.disableClient(client.clientId);
+    }
+  }
+}

--- a/src/user.js
+++ b/src/user.js
@@ -35,7 +35,12 @@ export default class User {
   }
 
   scopes() {
-    return this.roles.map(role => "assume:" + role);
+    let scopes = this.roles.map(role => "assume:" + role);
+    // add permission to manage scopes prefixed by the identity
+    ['create-client', 'delete-client', 'update-client', 'reset-access-token'].forEach(v => {
+      scopes.push("auth:" + v + ":" + this.identity + "/*");
+    });
+    return scopes;
   }
 
   createCredentials(options) {
@@ -44,11 +49,6 @@ export default class User {
     if (scopes.length === 0) {
       return null;
     }
-
-    // add permission to manage scopes prefixed by the identity
-    ['create-client', 'delete-client', 'update-client', 'reset-access-token'].forEach(v => {
-      scopes.push("auth:" + v + ":" + this.identity + "/*");
-    });
 
     return taskcluster.createTemporaryCredentials({
       clientId: this.identity,


### PR DESCRIPTION
This is pretty basic: expand scopes for all relenvant Users, expand scopes for all clients, compare, disable.

I'm not sure if it makes sense to enable clients when their scopes are satisfied.  On the one hand, this would preclude using "disabled" for anything other than this service (as it will enforce the setting of enabled/disabled).  On the other hand, if there is some issue that causes someone's group membership to change temporarily, it would be nice f the taskcluster clients are restored when that issue is fixed.  I'm open to thoughts on this one -- the implementation is easy (..else { enableClient(..) })