### PR TITLE
Bug 1255993: Generate temp creds even if there are no scopes

### DIFF
--- a/src/user.js
+++ b/src/user.js
@@ -41,9 +41,6 @@ export default class User {
   createCredentials(options) {
     assert(options);
     let scopes = this.scopes();
-    if (scopes.length === 0) {
-      return null;
-    }
 
     // add permission to manage scopes prefixed by the identity
     ['create-client', 'delete-client', 'update-client', 'reset-access-token'].forEach(v => {


### PR DESCRIPTION
This ensures that even a user with no associatd roles -- for example,
an unvouched mozillians user -- gets credentials.