### PR TITLE
Bug 1255994: add a `mozillians-unvouched' role

### DIFF
--- a/src/authz/mozillians.js
+++ b/src/authz/mozillians.js
@@ -30,20 +30,24 @@ class MozilliansAuthorizer {
 
     // Find the user
     let userLookup = await this.mozillians.users({email});
-    let mozilliansUser;
+    let mozilliansUser, vouched;
     if (userLookup.results.length === 1) {
       let u = userLookup.results[0];
-      if (u.is_vouched) {
-        debug(`found vouched username ${u.username} for ${email}`);
-        mozilliansUser = u.username;
-      }
-    }
-
-    if (!mozilliansUser) {
-      // If lookup failed we want to print a special error message
+      vouched = u.is_vouched;
+      mozilliansUser = u.username;
+    } else {
+      // If there is no associated mozillians user at all, do nothing.
       return;
     }
+
     user.addRole('mozillians-user:' + mozilliansUser);
+
+    // unvouched users just get the "mozillians-unvouched" role, and no
+    // group-based roles.  This allows them to complete the tutorial.
+    if (!vouched) {
+      user.addRole('mozillians-unvouched');
+      return
+    }
 
     // For each group to be considered we check if the user is a member
     let groupLookups = await Promise.all(

--- a/views/index.jade
+++ b/views/index.jade
@@ -119,10 +119,13 @@ html(lang='en')
               b Mozillian
               | , but do not have an LDAP account, sign in with Persona.
               | Your permissions will depend on the Mozillians groups you belong
-              | to.  If you do not have a Mozillians profile,&nbsp;
+              | to.  If you do not have a&nbsp;
+              b Public&nbsp;
+              | Mozillians profile,&nbsp;
               a(href='https://mozillians.org/en-US/')
                 | set one up
-              | &nbsp;and get vouched before logging into TaskCluster.
+              | &nbsp;now and make sure it is public.  Get vouched to gain access to
+              | additional scopes.
         div.row.login-option
           div.col-md-4
             button.btn.btn-block.btn-primary(data-toggle="modal", data-target="#manual-modal")


### PR DESCRIPTION
This role is useful for newcomers working through the tutorial.  Note,
however, that it requires a public Mozillians profile.