### PR TITLE
Public profiles are no longer required

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -30,6 +30,8 @@ Defaults:
         clientId:     !env TASKCLUSTER_CLIENT_ID
         accessToken:  !env TASKCLUSTER_ACCESS_TOKEN
   mozillians:
+    # NOTE: this API key needs to have the "Mozillians" level in order to access
+    # non-public profiles; see https://bugzilla.mozilla.org/show_bug.cgi?id=1259059
     apiKey:         !env MOZILLIANS_API_KEY
     allowedGroups:  !env:list MOZILLIANS_ALLOWED_GROUPS
   ldap:

--- a/views/index.jade
+++ b/views/index.jade
@@ -119,13 +119,10 @@ html(lang='en')
               b Mozillian
               | , but do not have an LDAP account, sign in with Persona.
               | Your permissions will depend on the Mozillians groups you belong
-              | to.  If you do not have a&nbsp;
-              b Public&nbsp;
-              | Mozillians profile,&nbsp;
+              | to.  If you do not have a Mozillians profile,&nbsp;
               a(href='https://mozillians.org/en-US/')
                 | set one up
-              | &nbsp;now and make sure it is public.  Get vouched to gain access to
-              | additional scopes.
+              | &nbsp;now.  Get vouched to gain access to additional scopes.
         div.row.login-option
           div.col-md-4
             button.btn.btn-block.btn-primary(data-toggle="modal", data-target="#manual-modal")


### PR DESCRIPTION
The substantive change was to the access level of the API key -- this just changes some comments and text.