### PR TITLE
Bug 1267249: Add persona support to the API

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -42,6 +42,9 @@ Defaults:
     secretAccessKey:  !env AWS_SECRET_ACCESS_KEY
     region:           us-west-2
     apiVersion:       2014-01-01
+  persona:
+    allowedAudiences:
+      - https://tools.taskcluster.net:443
   mozillians:
     # NOTE: this API key needs to have the "Mozillians" level in order to access
     # non-public profiles; see https://bugzilla.mozilla.org/show_bug.cgi?id=1259059
@@ -118,6 +121,9 @@ Profiles:
       credentials:
         clientId:     !env TASKCLUSTER_CLIENT_ID
         accessToken:  !env TASKCLUSTER_ACCESS_TOKEN
+    persona:
+      allowedAudiences:
+        - https://taskcluster-tools.ngrok.io:443
     mozillians:
       allowedGroups: ['taskcluster-users']
     ldap:

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -24,6 +24,11 @@
         }
       }
     },
+    "ajv": {
+      "version": "3.8.10",
+      "from": "ajv@>=3.8.5 <4.0.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-3.8.10.tgz"
+    },
     "align-text": {
       "version": "0.1.4",
       "from": "align-text@>=0.1.3 <0.2.0",
@@ -54,6 +59,11 @@
       "from": "ansi-styles@>=2.2.1 <3.0.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
     },
+    "app-root-dir": {
+      "version": "1.0.2",
+      "from": "app-root-dir@>=1.0.2 <2.0.0",
+      "resolved": "https://registry.npmjs.org/app-root-dir/-/app-root-dir-1.0.2.tgz"
+    },
     "argparse": {
       "version": "1.0.7",
       "from": "argparse@>=1.0.2 <2.0.0",
@@ -79,6 +89,11 @@
       "from": "assert-plus@0.1.5",
       "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz"
     },
+    "assertion-error": {
+      "version": "1.0.1",
+      "from": "assertion-error@>=1.0.1 <2.0.0",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.0.1.tgz"
+    },
     "assume": {
       "version": "1.4.1",
       "from": "assume@>=1.3.1 <2.0.0",
@@ -98,6 +113,67 @@
       "version": "1.5.2",
       "from": "async@*",
       "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz"
+    },
+    "aws-sdk": {
+      "version": "2.3.12",
+      "from": "aws-sdk@>=2.1.21 <3.0.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.3.12.tgz",
+      "dependencies": {
+        "lodash": {
+          "version": "3.5.0",
+          "from": "lodash@>=3.5.0 <3.6.0",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.5.0.tgz"
+        },
+        "sax": {
+          "version": "1.1.5",
+          "from": "sax@1.1.5",
+          "resolved": "https://registry.npmjs.org/sax/-/sax-1.1.5.tgz"
+        },
+        "xml2js": {
+          "version": "0.4.15",
+          "from": "xml2js@0.4.15",
+          "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.15.tgz"
+        },
+        "xmlbuilder": {
+          "version": "2.6.2",
+          "from": "xmlbuilder@2.6.2",
+          "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-2.6.2.tgz"
+        }
+      }
+    },
+    "aws-sdk-promise": {
+      "version": "0.0.2",
+      "from": "aws-sdk-promise@0.0.2",
+      "resolved": "https://registry.npmjs.org/aws-sdk-promise/-/aws-sdk-promise-0.0.2.tgz",
+      "dependencies": {
+        "promise": {
+          "version": "6.1.0",
+          "from": "promise@>=6.1.0 <7.0.0",
+          "resolved": "https://registry.npmjs.org/promise/-/promise-6.1.0.tgz"
+        }
+      }
+    },
+    "aws-sign2": {
+      "version": "0.5.0",
+      "from": "aws-sign2@>=0.5.0 <0.6.0",
+      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz"
+    },
+    "azure-table-node": {
+      "version": "1.4.1",
+      "from": "azure-table-node@1.4.1",
+      "resolved": "https://registry.npmjs.org/azure-table-node/-/azure-table-node-1.4.1.tgz",
+      "dependencies": {
+        "async": {
+          "version": "0.2.10",
+          "from": "async@>=0.2.10 <0.3.0",
+          "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
+        },
+        "lodash": {
+          "version": "2.4.2",
+          "from": "lodash@>=2.4.1 <2.5.0",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz"
+        }
+      }
     },
     "babel-compile": {
       "version": "0.0.3",
@@ -218,6 +294,11 @@
       "from": "balanced-match@>=0.3.0 <0.4.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz"
     },
+    "basic-auth": {
+      "version": "1.0.4",
+      "from": "basic-auth@>=1.0.3 <1.1.0",
+      "resolved": "https://registry.npmjs.org/basic-auth/-/basic-auth-1.0.4.tgz"
+    },
     "bitsyntax": {
       "version": "0.0.4",
       "from": "bitsyntax@>=0.0.4 <0.1.0",
@@ -248,6 +329,16 @@
       "from": "breakable@>=1.0.0 <1.1.0",
       "resolved": "https://registry.npmjs.org/breakable/-/breakable-1.0.0.tgz"
     },
+    "browserid-verify": {
+      "version": "0.1.2",
+      "from": "browserid-verify@latest",
+      "resolved": "https://registry.npmjs.org/browserid-verify/-/browserid-verify-0.1.2.tgz"
+    },
+    "buffer-crc32": {
+      "version": "0.2.3",
+      "from": "buffer-crc32@0.2.3",
+      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.3.tgz"
+    },
     "buffer-more-ints": {
       "version": "0.0.2",
       "from": "buffer-more-ints@0.0.2",
@@ -272,6 +363,18 @@
       "version": "0.1.3",
       "from": "center-align@>=0.1.1 <0.2.0",
       "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz"
+    },
+    "chai": {
+      "version": "3.5.0",
+      "from": "chai@>=1.9.2 <4.0.0",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-3.5.0.tgz",
+      "dependencies": {
+        "type-detect": {
+          "version": "1.0.0",
+          "from": "type-detect@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-1.0.0.tgz"
+        }
+      }
     },
     "chalk": {
       "version": "1.1.3",
@@ -304,6 +407,11 @@
       "version": "2.1.0",
       "from": "cliui@>=2.1.0 <3.0.0",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz"
+    },
+    "co": {
+      "version": "4.6.0",
+      "from": "co@>=4.6.0 <5.0.0",
+      "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz"
     },
     "combined-stream": {
       "version": "0.0.7",
@@ -397,6 +505,11 @@
       "from": "core-util-is@>=1.0.0 <1.1.0",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
     },
+    "crc": {
+      "version": "3.0.0",
+      "from": "crc@3.0.0",
+      "resolved": "https://registry.npmjs.org/crc/-/crc-3.0.0.tgz"
+    },
     "cryptiles": {
       "version": "2.0.5",
       "from": "cryptiles@>=2.0.0 <3.0.0",
@@ -417,6 +530,11 @@
       "from": "css-stringify@1.0.5",
       "resolved": "https://registry.npmjs.org/css-stringify/-/css-stringify-1.0.5.tgz"
     },
+    "ctype": {
+      "version": "0.5.3",
+      "from": "ctype@0.5.3",
+      "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz"
+    },
     "dashdash": {
       "version": "1.10.1",
       "from": "dashdash@1.10.1",
@@ -436,6 +554,11 @@
       "version": "0.1.3",
       "from": "deep-eql@>=0.1.0 <0.2.0",
       "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-0.1.3.tgz"
+    },
+    "deep-equal": {
+      "version": "1.0.1",
+      "from": "deep-equal@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz"
     },
     "defined": {
       "version": "1.0.0",
@@ -471,6 +594,11 @@
       "version": "4.3.1",
       "from": "detective@>=4.3.1 <5.0.0",
       "resolved": "https://registry.npmjs.org/detective/-/detective-4.3.1.tgz"
+    },
+    "diff": {
+      "version": "1.4.0",
+      "from": "diff@1.4.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-1.4.0.tgz"
     },
     "dtrace-provider": {
       "version": "0.6.0",
@@ -559,6 +687,16 @@
       "from": "fn.name@>=1.0.0 <1.1.0",
       "resolved": "https://registry.npmjs.org/fn.name/-/fn.name-1.0.1.tgz"
     },
+    "foreachasync": {
+      "version": "3.0.0",
+      "from": "foreachasync@>=3.0.0 <4.0.0",
+      "resolved": "https://registry.npmjs.org/foreachasync/-/foreachasync-3.0.0.tgz"
+    },
+    "forever-agent": {
+      "version": "0.5.2",
+      "from": "forever-agent@>=0.5.0 <0.6.0",
+      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.5.2.tgz"
+    },
     "form-data": {
       "version": "0.2.0",
       "from": "form-data@0.2.0",
@@ -631,6 +769,11 @@
       "from": "graceful-readlink@>=1.0.0",
       "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
     },
+    "growl": {
+      "version": "1.8.1",
+      "from": "growl@1.8.1",
+      "resolved": "https://registry.npmjs.org/growl/-/growl-1.8.1.tgz"
+    },
     "has-ansi": {
       "version": "2.0.0",
       "from": "has-ansi@>=2.0.0 <3.0.0",
@@ -651,10 +794,27 @@
       "from": "home-or-tmp@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-1.0.0.tgz"
     },
+    "hsts": {
+      "version": "1.0.0",
+      "from": "hsts@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/hsts/-/hsts-1.0.0.tgz"
+    },
     "http-errors": {
       "version": "1.4.0",
       "from": "http-errors@>=1.4.0 <1.5.0",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.4.0.tgz"
+    },
+    "http-signature": {
+      "version": "0.10.1",
+      "from": "http-signature@>=0.10.0 <0.11.0",
+      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz",
+      "dependencies": {
+        "asn1": {
+          "version": "0.1.11",
+          "from": "asn1@0.1.11",
+          "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz"
+        }
+      }
     },
     "iconv-lite": {
       "version": "0.4.13",
@@ -718,6 +878,11 @@
         }
       }
     },
+    "jmespath": {
+      "version": "0.15.0",
+      "from": "jmespath@0.15.0",
+      "resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.15.0.tgz"
+    },
     "js-tokens": {
       "version": "1.0.1",
       "from": "js-tokens@1.0.1",
@@ -730,7 +895,8 @@
       "dependencies": {
         "esprima": {
           "version": "2.7.2",
-          "from": "esprima@>=2.6.0 <3.0.0"
+          "from": "esprima@2.7.2",
+          "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.2.tgz"
         }
       }
     },
@@ -738,6 +904,16 @@
       "version": "0.5.0",
       "from": "jsesc@>=0.5.0 <0.6.0",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz"
+    },
+    "json-stable-stringify": {
+      "version": "1.0.1",
+      "from": "json-stable-stringify@>=1.0.1 <2.0.0",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz"
+    },
+    "json-stringify-safe": {
+      "version": "5.0.1",
+      "from": "json-stringify-safe@>=5.0.0 <5.1.0",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
     },
     "json3": {
       "version": "3.3.2",
@@ -748,6 +924,11 @@
       "version": "0.4.0",
       "from": "json5@>=0.4.0 <0.5.0",
       "resolved": "https://registry.npmjs.org/json5/-/json5-0.4.0.tgz"
+    },
+    "jsonify": {
+      "version": "0.0.0",
+      "from": "jsonify@>=0.0.0 <0.1.0",
+      "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz"
     },
     "jstransformer": {
       "version": "0.0.2",
@@ -813,6 +994,16 @@
       "from": "longest@>=1.0.1 <2.0.0",
       "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz"
     },
+    "lru-cache": {
+      "version": "2.7.3",
+      "from": "lru-cache@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz"
+    },
+    "lsmod": {
+      "version": "1.0.0",
+      "from": "lsmod@1.0.0",
+      "resolved": "https://registry.npmjs.org/lsmod/-/lsmod-1.0.0.tgz"
+    },
     "media-typer": {
       "version": "0.3.0",
       "from": "media-typer@0.3.0",
@@ -865,6 +1056,16 @@
         }
       }
     },
+    "morgan": {
+      "version": "1.7.0",
+      "from": "morgan@>=1.5.2 <2.0.0",
+      "resolved": "https://registry.npmjs.org/morgan/-/morgan-1.7.0.tgz"
+    },
+    "morgan-debug": {
+      "version": "1.0.0",
+      "from": "morgan-debug@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/morgan-debug/-/morgan-debug-1.0.0.tgz"
+    },
     "mozillians-client": {
       "version": "0.1.1",
       "from": "mozillians-client@>=0.1.1 <0.2.0",
@@ -907,15 +1108,36 @@
       "from": "negotiator@0.5.3",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.5.3.tgz"
     },
+    "nock": {
+      "version": "4.1.0",
+      "from": "nock@>=4.0.0 <5.0.0",
+      "resolved": "https://registry.npmjs.org/nock/-/nock-4.1.0.tgz",
+      "dependencies": {
+        "lodash": {
+          "version": "2.4.1",
+          "from": "lodash@2.4.1"
+        }
+      }
+    },
     "node-forge": {
       "version": "0.2.24",
       "from": "node-forge@0.2.24",
       "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.2.24.tgz"
     },
+    "node-uuid": {
+      "version": "1.4.7",
+      "from": "node-uuid@>=1.4.1 <1.5.0",
+      "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz"
+    },
     "number-is-nan": {
       "version": "1.0.0",
       "from": "number-is-nan@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
+    },
+    "oauth-sign": {
+      "version": "0.3.0",
+      "from": "oauth-sign@>=0.3.0 <0.4.0",
+      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.3.0.tgz"
     },
     "object-inspect": {
       "version": "1.0.2",
@@ -1058,6 +1280,11 @@
         }
       }
     },
+    "propagate": {
+      "version": "0.3.1",
+      "from": "propagate@>=0.3.0 <0.4.0",
+      "resolved": "https://registry.npmjs.org/propagate/-/propagate-0.3.1.tgz"
+    },
     "proxy-addr": {
       "version": "1.0.10",
       "from": "proxy-addr@>=1.0.10 <1.1.0",
@@ -1087,6 +1314,18 @@
       "version": "1.0.3",
       "from": "range-parser@>=1.0.3 <1.1.0",
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.0.3.tgz"
+    },
+    "raven": {
+      "version": "0.11.0",
+      "from": "raven@>=0.11.0 <0.12.0",
+      "resolved": "https://registry.npmjs.org/raven/-/raven-0.11.0.tgz",
+      "dependencies": {
+        "cookie": {
+          "version": "0.1.0",
+          "from": "cookie@0.1.0",
+          "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.1.0.tgz"
+        }
+      }
     },
     "raw-body": {
       "version": "2.1.6",
@@ -1157,6 +1396,52 @@
       "from": "repeating@>=1.1.2 <2.0.0",
       "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz"
     },
+    "request": {
+      "version": "2.34.0",
+      "from": "request@>=2.34.0 <2.35.0",
+      "resolved": "https://registry.npmjs.org/request/-/request-2.34.0.tgz",
+      "dependencies": {
+        "async": {
+          "version": "0.9.2",
+          "from": "async@>=0.9.0 <0.10.0"
+        },
+        "boom": {
+          "version": "0.4.2",
+          "from": "boom@>=0.4.0 <0.5.0"
+        },
+        "cryptiles": {
+          "version": "0.2.2",
+          "from": "cryptiles@>=0.2.0 <0.3.0"
+        },
+        "form-data": {
+          "version": "0.1.4",
+          "from": "form-data@>=0.1.0 <0.2.0",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.1.4.tgz"
+        },
+        "hawk": {
+          "version": "1.0.0",
+          "from": "hawk@>=1.0.0 <1.1.0",
+          "resolved": "https://registry.npmjs.org/hawk/-/hawk-1.0.0.tgz"
+        },
+        "hoek": {
+          "version": "0.9.1",
+          "from": "hoek@>=0.9.0 <0.10.0"
+        },
+        "mime": {
+          "version": "1.2.11",
+          "from": "mime@>=1.2.9 <1.3.0"
+        },
+        "qs": {
+          "version": "0.6.6",
+          "from": "qs@>=0.6.0 <0.7.0",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-0.6.6.tgz"
+        },
+        "sntp": {
+          "version": "0.2.4",
+          "from": "sntp@>=0.2.0 <0.3.0"
+        }
+      }
+    },
     "requires-port": {
       "version": "1.0.0",
       "from": "requires-port@>=1.0.0 <1.1.0",
@@ -1216,6 +1501,11 @@
       "from": "shebang-regex@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz"
     },
+    "sigmund": {
+      "version": "1.0.1",
+      "from": "sigmund@>=1.0.0 <1.1.0",
+      "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
+    },
     "simple-fmt": {
       "version": "0.1.0",
       "from": "simple-fmt@>=0.1.0 <0.2.0",
@@ -1272,6 +1562,11 @@
       "version": "0.1.5",
       "from": "stable@>=0.1.3 <0.2.0",
       "resolved": "https://registry.npmjs.org/stable/-/stable-0.1.5.tgz"
+    },
+    "stack-trace": {
+      "version": "0.0.7",
+      "from": "stack-trace@0.0.7",
+      "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.7.tgz"
     },
     "statuses": {
       "version": "1.2.1",
@@ -1364,12 +1659,755 @@
     },
     "taskcluster-client": {
       "version": "0.23.16",
-      "from": "taskcluster-client@>=0.23.12 <0.24.0",
+      "from": "taskcluster-client@0.23.16",
+      "resolved": "https://registry.npmjs.org/taskcluster-client/-/taskcluster-client-0.23.16.tgz",
       "dependencies": {
         "promise": {
           "version": "6.1.0",
           "from": "promise@>=6.1.0 <7.0.0",
           "resolved": "https://registry.npmjs.org/promise/-/promise-6.1.0.tgz"
+        }
+      }
+    },
+    "taskcluster-lib-api": {
+      "version": "1.0.0",
+      "from": "taskcluster-lib-api@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/taskcluster-lib-api/-/taskcluster-lib-api-1.0.0.tgz",
+      "dependencies": {
+        "accepts": {
+          "version": "1.1.4",
+          "from": "accepts@>=1.1.0 <1.2.0",
+          "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.1.4.tgz"
+        },
+        "async": {
+          "version": "0.9.2",
+          "from": "async@>=0.9.0 <0.10.0",
+          "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz"
+        },
+        "babel-runtime": {
+          "version": "6.9.0",
+          "from": "babel-runtime@>=6.3.19 <7.0.0",
+          "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.9.0.tgz"
+        },
+        "body-parser": {
+          "version": "1.13.3",
+          "from": "body-parser@1.13.3",
+          "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.13.3.tgz"
+        },
+        "bytes": {
+          "version": "2.1.0",
+          "from": "bytes@2.1.0",
+          "resolved": "https://registry.npmjs.org/bytes/-/bytes-2.1.0.tgz"
+        },
+        "component-emitter": {
+          "version": "1.1.2",
+          "from": "component-emitter@1.1.2",
+          "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.1.2.tgz"
+        },
+        "cookie": {
+          "version": "0.1.2",
+          "from": "cookie@0.1.2",
+          "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.1.2.tgz"
+        },
+        "cookie-signature": {
+          "version": "1.0.5",
+          "from": "cookie-signature@1.0.5",
+          "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.5.tgz"
+        },
+        "cookiejar": {
+          "version": "2.0.1",
+          "from": "cookiejar@2.0.1",
+          "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.0.1.tgz"
+        },
+        "core-js": {
+          "version": "2.4.0",
+          "from": "core-js@>=2.4.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.4.0.tgz"
+        },
+        "delayed-stream": {
+          "version": "1.0.0",
+          "from": "delayed-stream@>=1.0.0 <1.1.0",
+          "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz"
+        },
+        "depd": {
+          "version": "1.0.1",
+          "from": "depd@>=1.0.1 <1.1.0",
+          "resolved": "https://registry.npmjs.org/depd/-/depd-1.0.1.tgz"
+        },
+        "destroy": {
+          "version": "1.0.3",
+          "from": "destroy@1.0.3",
+          "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.3.tgz"
+        },
+        "ee-first": {
+          "version": "1.1.0",
+          "from": "ee-first@1.1.0",
+          "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.0.tgz"
+        },
+        "escape-html": {
+          "version": "1.0.1",
+          "from": "escape-html@1.0.1",
+          "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.1.tgz"
+        },
+        "etag": {
+          "version": "1.3.1",
+          "from": "etag@>=1.3.0 <1.4.0",
+          "resolved": "https://registry.npmjs.org/etag/-/etag-1.3.1.tgz"
+        },
+        "express": {
+          "version": "4.9.0",
+          "from": "express@4.9.0",
+          "resolved": "https://registry.npmjs.org/express/-/express-4.9.0.tgz",
+          "dependencies": {
+            "debug": {
+              "version": "2.0.0",
+              "from": "debug@>=2.0.0 <2.1.0",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-2.0.0.tgz"
+            },
+            "depd": {
+              "version": "0.4.4",
+              "from": "depd@0.4.4",
+              "resolved": "https://registry.npmjs.org/depd/-/depd-0.4.4.tgz"
+            },
+            "on-finished": {
+              "version": "2.1.1",
+              "from": "on-finished@>=2.1.0 <2.2.0",
+              "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.1.1.tgz"
+            },
+            "qs": {
+              "version": "2.2.3",
+              "from": "qs@2.2.3",
+              "resolved": "https://registry.npmjs.org/qs/-/qs-2.2.3.tgz"
+            },
+            "type-is": {
+              "version": "1.5.7",
+              "from": "type-is@>=1.5.1 <1.6.0",
+              "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.5.7.tgz"
+            }
+          }
+        },
+        "extend": {
+          "version": "1.2.1",
+          "from": "extend@>=1.2.1 <1.3.0",
+          "resolved": "https://registry.npmjs.org/extend/-/extend-1.2.1.tgz"
+        },
+        "finalhandler": {
+          "version": "0.2.0",
+          "from": "finalhandler@0.2.0",
+          "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-0.2.0.tgz",
+          "dependencies": {
+            "debug": {
+              "version": "2.0.0",
+              "from": "debug@>=2.0.0 <2.1.0"
+            }
+          }
+        },
+        "form-data": {
+          "version": "0.1.3",
+          "from": "form-data@0.1.3",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.1.3.tgz"
+        },
+        "formidable": {
+          "version": "1.0.14",
+          "from": "formidable@1.0.14",
+          "resolved": "https://registry.npmjs.org/formidable/-/formidable-1.0.14.tgz"
+        },
+        "fresh": {
+          "version": "0.2.4",
+          "from": "fresh@0.2.4",
+          "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.2.4.tgz"
+        },
+        "hawk": {
+          "version": "2.3.0",
+          "from": "hawk@2.3.0",
+          "resolved": "https://registry.npmjs.org/hawk/-/hawk-2.3.0.tgz"
+        },
+        "http-errors": {
+          "version": "1.3.1",
+          "from": "http-errors@>=1.3.1 <1.4.0",
+          "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.3.1.tgz"
+        },
+        "iconv-lite": {
+          "version": "0.4.11",
+          "from": "iconv-lite@0.4.11",
+          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.11.tgz"
+        },
+        "ipaddr.js": {
+          "version": "0.1.2",
+          "from": "ipaddr.js@0.1.2",
+          "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-0.1.2.tgz"
+        },
+        "lodash": {
+          "version": "2.4.1",
+          "from": "lodash@2.4.1",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz"
+        },
+        "merge-descriptors": {
+          "version": "0.0.2",
+          "from": "merge-descriptors@0.0.2",
+          "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-0.0.2.tgz"
+        },
+        "methods": {
+          "version": "1.1.0",
+          "from": "methods@1.1.0",
+          "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.0.tgz"
+        },
+        "mime": {
+          "version": "1.2.11",
+          "from": "mime@1.2.11",
+          "resolved": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz"
+        },
+        "mime-db": {
+          "version": "1.12.0",
+          "from": "mime-db@>=1.12.0 <1.13.0",
+          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.12.0.tgz"
+        },
+        "mime-types": {
+          "version": "2.0.14",
+          "from": "mime-types@>=2.0.4 <2.1.0",
+          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.14.tgz"
+        },
+        "ms": {
+          "version": "0.6.2",
+          "from": "ms@0.6.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-0.6.2.tgz"
+        },
+        "negotiator": {
+          "version": "0.4.9",
+          "from": "negotiator@0.4.9",
+          "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.4.9.tgz"
+        },
+        "path-to-regexp": {
+          "version": "0.1.3",
+          "from": "path-to-regexp@0.1.3",
+          "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.3.tgz"
+        },
+        "proxy-addr": {
+          "version": "1.0.1",
+          "from": "proxy-addr@1.0.1",
+          "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-1.0.1.tgz"
+        },
+        "qs": {
+          "version": "4.0.0",
+          "from": "qs@4.0.0",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-4.0.0.tgz"
+        },
+        "readable-stream": {
+          "version": "1.0.27-1",
+          "from": "readable-stream@1.0.27-1",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.27-1.tgz"
+        },
+        "send": {
+          "version": "0.9.1",
+          "from": "send@0.9.1",
+          "resolved": "https://registry.npmjs.org/send/-/send-0.9.1.tgz",
+          "dependencies": {
+            "debug": {
+              "version": "2.0.0",
+              "from": "debug@>=2.0.0 <2.1.0"
+            },
+            "depd": {
+              "version": "0.4.4",
+              "from": "depd@0.4.4",
+              "resolved": "https://registry.npmjs.org/depd/-/depd-0.4.4.tgz"
+            },
+            "ee-first": {
+              "version": "1.0.5",
+              "from": "ee-first@1.0.5",
+              "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.0.5.tgz"
+            },
+            "on-finished": {
+              "version": "2.1.0",
+              "from": "on-finished@2.1.0",
+              "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.1.0.tgz"
+            }
+          }
+        },
+        "serve-static": {
+          "version": "1.6.5",
+          "from": "serve-static@>=1.6.1 <1.7.0",
+          "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.6.5.tgz",
+          "dependencies": {
+            "debug": {
+              "version": "2.0.0",
+              "from": "debug@>=2.0.0 <2.1.0"
+            },
+            "depd": {
+              "version": "0.4.5",
+              "from": "depd@0.4.5",
+              "resolved": "https://registry.npmjs.org/depd/-/depd-0.4.5.tgz"
+            },
+            "ee-first": {
+              "version": "1.0.5",
+              "from": "ee-first@1.0.5",
+              "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.0.5.tgz"
+            },
+            "etag": {
+              "version": "1.4.0",
+              "from": "etag@>=1.4.0 <1.5.0",
+              "resolved": "https://registry.npmjs.org/etag/-/etag-1.4.0.tgz"
+            },
+            "on-finished": {
+              "version": "2.1.0",
+              "from": "on-finished@2.1.0",
+              "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.1.0.tgz"
+            },
+            "send": {
+              "version": "0.9.3",
+              "from": "send@0.9.3",
+              "resolved": "https://registry.npmjs.org/send/-/send-0.9.3.tgz"
+            }
+          }
+        },
+        "superagent": {
+          "version": "0.18.2",
+          "from": "superagent@0.18.2",
+          "resolved": "https://registry.npmjs.org/superagent/-/superagent-0.18.2.tgz",
+          "dependencies": {
+            "debug": {
+              "version": "1.0.4",
+              "from": "debug@>=1.0.1 <1.1.0",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-1.0.4.tgz"
+            },
+            "methods": {
+              "version": "1.0.1",
+              "from": "methods@1.0.1",
+              "resolved": "https://registry.npmjs.org/methods/-/methods-1.0.1.tgz"
+            },
+            "qs": {
+              "version": "0.6.6",
+              "from": "qs@0.6.6",
+              "resolved": "https://registry.npmjs.org/qs/-/qs-0.6.6.tgz"
+            }
+          }
+        },
+        "superagent-hawk": {
+          "version": "0.0.4",
+          "from": "superagent-hawk@0.0.4",
+          "resolved": "https://registry.npmjs.org/superagent-hawk/-/superagent-hawk-0.0.4.tgz",
+          "dependencies": {
+            "boom": {
+              "version": "0.4.2",
+              "from": "boom@>=0.4.0 <0.5.0",
+              "resolved": "https://registry.npmjs.org/boom/-/boom-0.4.2.tgz"
+            },
+            "cryptiles": {
+              "version": "0.2.2",
+              "from": "cryptiles@>=0.2.0 <0.3.0",
+              "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-0.2.2.tgz"
+            },
+            "hawk": {
+              "version": "1.0.0",
+              "from": "hawk@>=1.0.0 <1.1.0",
+              "resolved": "https://registry.npmjs.org/hawk/-/hawk-1.0.0.tgz"
+            },
+            "hoek": {
+              "version": "0.9.1",
+              "from": "hoek@>=0.9.0 <0.10.0",
+              "resolved": "https://registry.npmjs.org/hoek/-/hoek-0.9.1.tgz"
+            },
+            "sntp": {
+              "version": "0.2.4",
+              "from": "sntp@>=0.2.0 <0.3.0",
+              "resolved": "https://registry.npmjs.org/sntp/-/sntp-0.2.4.tgz"
+            }
+          }
+        },
+        "superagent-promise": {
+          "version": "0.1.2",
+          "from": "superagent-promise@0.1.2",
+          "resolved": "https://registry.npmjs.org/superagent-promise/-/superagent-promise-0.1.2.tgz"
+        },
+        "taskcluster-client": {
+          "version": "0.23.4",
+          "from": "taskcluster-client@0.23.4",
+          "resolved": "https://registry.npmjs.org/taskcluster-client/-/taskcluster-client-0.23.4.tgz",
+          "dependencies": {
+            "async": {
+              "version": "1.5.2",
+              "from": "async@>=1.4.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz"
+            },
+            "combined-stream": {
+              "version": "1.0.5",
+              "from": "combined-stream@>=1.0.5 <2.0.0",
+              "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz"
+            },
+            "component-emitter": {
+              "version": "1.2.1",
+              "from": "component-emitter@>=1.2.0 <1.3.0",
+              "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz"
+            },
+            "cookiejar": {
+              "version": "2.0.6",
+              "from": "cookiejar@2.0.6",
+              "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.0.6.tgz"
+            },
+            "extend": {
+              "version": "3.0.0",
+              "from": "extend@3.0.0",
+              "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz"
+            },
+            "form-data": {
+              "version": "1.0.0-rc3",
+              "from": "form-data@1.0.0-rc3",
+              "resolved": "https://registry.npmjs.org/form-data/-/form-data-1.0.0-rc3.tgz"
+            },
+            "hawk": {
+              "version": "2.3.1",
+              "from": "hawk@>=2.3.1 <3.0.0",
+              "resolved": "https://registry.npmjs.org/hawk/-/hawk-2.3.1.tgz"
+            },
+            "lodash": {
+              "version": "3.10.1",
+              "from": "lodash@>=3.6.0 <4.0.0",
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
+            },
+            "methods": {
+              "version": "1.1.2",
+              "from": "methods@>=1.1.1 <1.2.0",
+              "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz"
+            },
+            "mime": {
+              "version": "1.3.4",
+              "from": "mime@1.3.4",
+              "resolved": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz"
+            },
+            "mime-db": {
+              "version": "1.23.0",
+              "from": "mime-db@>=1.23.0 <1.24.0",
+              "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.23.0.tgz"
+            },
+            "mime-types": {
+              "version": "2.1.11",
+              "from": "mime-types@>=2.1.3 <3.0.0",
+              "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.11.tgz"
+            },
+            "promise": {
+              "version": "6.1.0",
+              "from": "promise@>=6.1.0 <7.0.0"
+            },
+            "qs": {
+              "version": "2.3.3",
+              "from": "qs@2.3.3",
+              "resolved": "https://registry.npmjs.org/qs/-/qs-2.3.3.tgz"
+            },
+            "superagent": {
+              "version": "1.8.3",
+              "from": "superagent@>=1.1.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/superagent/-/superagent-1.8.3.tgz"
+            },
+            "superagent-hawk": {
+              "version": "0.0.6",
+              "from": "superagent-hawk@>=0.0.6 <0.0.7",
+              "resolved": "https://registry.npmjs.org/superagent-hawk/-/superagent-hawk-0.0.6.tgz",
+              "dependencies": {
+                "boom": {
+                  "version": "0.4.2",
+                  "from": "boom@>=0.4.0 <0.5.0"
+                },
+                "cryptiles": {
+                  "version": "0.2.2",
+                  "from": "cryptiles@>=0.2.0 <0.3.0"
+                },
+                "hawk": {
+                  "version": "1.0.0",
+                  "from": "hawk@>=1.0.0 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/hawk/-/hawk-1.0.0.tgz"
+                },
+                "hoek": {
+                  "version": "0.9.1",
+                  "from": "hoek@>=0.9.0 <0.10.0"
+                },
+                "qs": {
+                  "version": "0.6.6",
+                  "from": "qs@>=0.6.6 <0.7.0",
+                  "resolved": "https://registry.npmjs.org/qs/-/qs-0.6.6.tgz"
+                },
+                "sntp": {
+                  "version": "0.2.4",
+                  "from": "sntp@>=0.2.0 <0.3.0"
+                }
+              }
+            },
+            "superagent-promise": {
+              "version": "0.2.0",
+              "from": "superagent-promise@>=0.2.0 <0.3.0",
+              "resolved": "https://registry.npmjs.org/superagent-promise/-/superagent-promise-0.2.0.tgz"
+            }
+          }
+        }
+      }
+    },
+    "taskcluster-lib-app": {
+      "version": "1.0.0",
+      "from": "taskcluster-lib-app@>=1.0.0 <2.0.0",
+      "dependencies": {
+        "accepts": {
+          "version": "1.1.4",
+          "from": "accepts@>=1.1.0 <1.2.0"
+        },
+        "async": {
+          "version": "0.9.2",
+          "from": "async@>=0.9.0 <0.10.0"
+        },
+        "babel-runtime": {
+          "version": "6.9.0",
+          "from": "babel-runtime@>=6.0.14 <7.0.0"
+        },
+        "component-emitter": {
+          "version": "1.1.2",
+          "from": "component-emitter@1.1.2"
+        },
+        "cookie": {
+          "version": "0.1.2",
+          "from": "cookie@0.1.2",
+          "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.1.2.tgz"
+        },
+        "cookie-signature": {
+          "version": "1.0.5",
+          "from": "cookie-signature@1.0.5"
+        },
+        "cookiejar": {
+          "version": "2.0.1",
+          "from": "cookiejar@2.0.1"
+        },
+        "core-js": {
+          "version": "2.4.0",
+          "from": "core-js@>=2.4.0 <3.0.0"
+        },
+        "depd": {
+          "version": "0.4.4",
+          "from": "depd@0.4.4",
+          "resolved": "https://registry.npmjs.org/depd/-/depd-0.4.4.tgz"
+        },
+        "destroy": {
+          "version": "1.0.3",
+          "from": "destroy@1.0.3"
+        },
+        "ee-first": {
+          "version": "1.1.0",
+          "from": "ee-first@1.1.0"
+        },
+        "escape-html": {
+          "version": "1.0.1",
+          "from": "escape-html@1.0.1"
+        },
+        "etag": {
+          "version": "1.3.1",
+          "from": "etag@>=1.3.0 <1.4.0"
+        },
+        "express": {
+          "version": "4.9.0",
+          "from": "express@4.9.0",
+          "dependencies": {
+            "debug": {
+              "version": "2.0.0",
+              "from": "debug@>=2.0.0 <2.1.0",
+              "dependencies": {
+                "ms": {
+                  "version": "0.6.2",
+                  "from": "ms@0.6.2"
+                }
+              }
+            }
+          }
+        },
+        "express-sslify": {
+          "version": "0.1.0",
+          "from": "express-sslify@0.1.0",
+          "resolved": "https://registry.npmjs.org/express-sslify/-/express-sslify-0.1.0.tgz"
+        },
+        "extend": {
+          "version": "1.2.1",
+          "from": "extend@>=1.2.1 <1.3.0"
+        },
+        "finalhandler": {
+          "version": "0.2.0",
+          "from": "finalhandler@0.2.0",
+          "dependencies": {
+            "debug": {
+              "version": "2.0.0",
+              "from": "debug@>=2.0.0 <2.1.0",
+              "dependencies": {
+                "ms": {
+                  "version": "0.6.2",
+                  "from": "ms@0.6.2"
+                }
+              }
+            }
+          }
+        },
+        "form-data": {
+          "version": "0.1.3",
+          "from": "form-data@0.1.3"
+        },
+        "formidable": {
+          "version": "1.0.14",
+          "from": "formidable@1.0.14"
+        },
+        "fresh": {
+          "version": "0.2.4",
+          "from": "fresh@0.2.4"
+        },
+        "ipaddr.js": {
+          "version": "0.1.2",
+          "from": "ipaddr.js@0.1.2"
+        },
+        "lodash": {
+          "version": "2.4.1",
+          "from": "lodash@2.4.1"
+        },
+        "merge-descriptors": {
+          "version": "0.0.2",
+          "from": "merge-descriptors@0.0.2"
+        },
+        "methods": {
+          "version": "1.1.0",
+          "from": "methods@1.1.0"
+        },
+        "mime": {
+          "version": "1.2.11",
+          "from": "mime@1.2.11"
+        },
+        "mime-db": {
+          "version": "1.12.0",
+          "from": "mime-db@>=1.12.0 <1.13.0"
+        },
+        "mime-types": {
+          "version": "2.0.14",
+          "from": "mime-types@>=2.0.4 <2.1.0"
+        },
+        "negotiator": {
+          "version": "0.4.9",
+          "from": "negotiator@0.4.9"
+        },
+        "on-finished": {
+          "version": "2.1.1",
+          "from": "on-finished@>=2.1.0 <2.2.0"
+        },
+        "path-to-regexp": {
+          "version": "0.1.3",
+          "from": "path-to-regexp@0.1.3"
+        },
+        "proxy-addr": {
+          "version": "1.0.1",
+          "from": "proxy-addr@1.0.1"
+        },
+        "qs": {
+          "version": "2.2.3",
+          "from": "qs@2.2.3",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-2.2.3.tgz"
+        },
+        "readable-stream": {
+          "version": "1.0.27-1",
+          "from": "readable-stream@1.0.27-1"
+        },
+        "send": {
+          "version": "0.9.1",
+          "from": "send@0.9.1",
+          "dependencies": {
+            "debug": {
+              "version": "2.0.0",
+              "from": "debug@>=2.0.0 <2.1.0"
+            },
+            "ee-first": {
+              "version": "1.0.5",
+              "from": "ee-first@1.0.5",
+              "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.0.5.tgz"
+            },
+            "ms": {
+              "version": "0.6.2",
+              "from": "ms@0.6.2"
+            },
+            "on-finished": {
+              "version": "2.1.0",
+              "from": "on-finished@2.1.0",
+              "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.1.0.tgz"
+            }
+          }
+        },
+        "serve-static": {
+          "version": "1.6.5",
+          "from": "serve-static@>=1.6.1 <1.7.0",
+          "dependencies": {
+            "debug": {
+              "version": "2.0.0",
+              "from": "debug@>=2.0.0 <2.1.0",
+              "dependencies": {
+                "ms": {
+                  "version": "0.6.2",
+                  "from": "ms@0.6.2"
+                }
+              }
+            },
+            "depd": {
+              "version": "0.4.5",
+              "from": "depd@0.4.5",
+              "resolved": "https://registry.npmjs.org/depd/-/depd-0.4.5.tgz"
+            },
+            "ee-first": {
+              "version": "1.0.5",
+              "from": "ee-first@1.0.5",
+              "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.0.5.tgz"
+            },
+            "etag": {
+              "version": "1.4.0",
+              "from": "etag@>=1.4.0 <1.5.0",
+              "resolved": "https://registry.npmjs.org/etag/-/etag-1.4.0.tgz"
+            },
+            "on-finished": {
+              "version": "2.1.0",
+              "from": "on-finished@2.1.0",
+              "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.1.0.tgz"
+            },
+            "send": {
+              "version": "0.9.3",
+              "from": "send@0.9.3",
+              "resolved": "https://registry.npmjs.org/send/-/send-0.9.3.tgz",
+              "dependencies": {
+                "ms": {
+                  "version": "0.6.2",
+                  "from": "ms@0.6.2"
+                }
+              }
+            }
+          }
+        },
+        "superagent": {
+          "version": "0.18.2",
+          "from": "superagent@>=0.18.2 <0.19.0",
+          "dependencies": {
+            "debug": {
+              "version": "1.0.4",
+              "from": "debug@>=1.0.1 <1.1.0",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-1.0.4.tgz",
+              "dependencies": {
+                "ms": {
+                  "version": "0.6.2",
+                  "from": "ms@0.6.2"
+                }
+              }
+            },
+            "methods": {
+              "version": "1.0.1",
+              "from": "methods@1.0.1",
+              "resolved": "https://registry.npmjs.org/methods/-/methods-1.0.1.tgz"
+            },
+            "qs": {
+              "version": "0.6.6",
+              "from": "qs@0.6.6",
+              "resolved": "https://registry.npmjs.org/qs/-/qs-0.6.6.tgz"
+            }
+          }
+        },
+        "superagent-promise": {
+          "version": "0.1.2",
+          "from": "superagent-promise@>=0.1.2 <0.2.0"
+        },
+        "type-is": {
+          "version": "1.5.7",
+          "from": "type-is@>=1.5.1 <1.6.0"
         }
       }
     },
@@ -1393,10 +2431,52 @@
       "from": "taskcluster-lib-scopes@>=0.8.8 <0.9.0",
       "resolved": "https://registry.npmjs.org/taskcluster-lib-scopes/-/taskcluster-lib-scopes-0.8.8.tgz"
     },
+    "taskcluster-lib-validate": {
+      "version": "1.0.0",
+      "from": "taskcluster-lib-validate@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/taskcluster-lib-validate/-/taskcluster-lib-validate-1.0.0.tgz",
+      "dependencies": {
+        "ajv": {
+          "version": "4.0.5",
+          "from": "ajv@>=4.0.4 <5.0.0",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.0.5.tgz"
+        },
+        "babel-runtime": {
+          "version": "6.9.0",
+          "from": "babel-runtime@>=6.0.0 <7.0.0"
+        },
+        "core-js": {
+          "version": "2.4.0",
+          "from": "core-js@>=2.4.0 <3.0.0"
+        },
+        "lodash": {
+          "version": "4.12.0",
+          "from": "lodash@>=4.5.1 <5.0.0",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.12.0.tgz"
+        },
+        "url-join": {
+          "version": "1.1.0",
+          "from": "url-join@>=1.1.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/url-join/-/url-join-1.1.0.tgz"
+        }
+      }
+    },
     "through": {
       "version": "2.3.8",
       "from": "through@>=2.3.8 <2.4.0",
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
+    },
+    "through2": {
+      "version": "0.6.5",
+      "from": "through2@>=0.6.3 <0.7.0",
+      "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
+      "dependencies": {
+        "readable-stream": {
+          "version": "1.0.34",
+          "from": "readable-stream@>=1.0.33-1 <1.1.0-0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz"
+        }
+      }
     },
     "to-fast-properties": {
       "version": "1.0.2",
@@ -1407,6 +2487,11 @@
       "version": "1.0.0",
       "from": "topo-sort@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/topo-sort/-/topo-sort-1.0.0.tgz"
+    },
+    "tough-cookie": {
+      "version": "2.2.2",
+      "from": "tough-cookie@>=0.12.0",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.2.2.tgz"
     },
     "transformers": {
       "version": "2.1.0",
@@ -1449,6 +2534,16 @@
       "version": "0.1.2",
       "from": "tryor@>=0.1.2 <0.2.0",
       "resolved": "https://registry.npmjs.org/tryor/-/tryor-0.1.2.tgz"
+    },
+    "tunnel": {
+      "version": "0.0.4",
+      "from": "tunnel@>=0.0.0 <0.1.0",
+      "resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.4.tgz"
+    },
+    "tunnel-agent": {
+      "version": "0.3.0",
+      "from": "tunnel-agent@>=0.3.0 <0.4.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.3.0.tgz"
     },
     "type-detect": {
       "version": "0.1.1",
@@ -1536,6 +2631,11 @@
       "version": "2.0.1",
       "from": "void-elements@>=2.0.1 <2.1.0",
       "resolved": "https://registry.npmjs.org/void-elements/-/void-elements-2.0.1.tgz"
+    },
+    "walk": {
+      "version": "2.3.9",
+      "from": "walk@>=2.3.9 <3.0.0",
+      "resolved": "https://registry.npmjs.org/walk/-/walk-2.3.9.tgz"
     },
     "websocket-driver": {
       "version": "0.6.4",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "babel-compile": "^0.0.3",
     "babel-runtime": "^5.8.25",
     "body-parser": "^1.14.1",
+    "browserid-verify": "^0.1.2",
     "connect-flash": "^0.1.1",
     "cookie-session": "^1.2.0",
     "debug": "^2.2.0",

--- a/schemas/persona-request.yml
+++ b/schemas/persona-request.yml
@@ -1,0 +1,19 @@
+$schema:                  http://json-schema.org/draft-04/schema#
+title:                    "Persona Assertion Request"
+type:                     object
+properties:
+  assertion:
+    description: |
+      The Persona assertion from `navigator.id.get`
+    type:                 string
+  audience:
+    description: |
+      The audience against which to verify the assertion, in the format
+      `https://site.com:443`.  This must be from a whitelist of sites
+      configured in the login service.
+    type:                 string
+additionalProperties:     false
+required:
+  - assertion
+  - audience
+

--- a/src/authz.js
+++ b/src/authz.js
@@ -1,0 +1,39 @@
+/**
+ * The authorizer is responsible for taking User objects that only have
+ * an identity set, and adding a collection of roles based on that
+ * identity.  This is done by means of a set of plugins in the `authz`
+ * directory and named in the configuration.
+ */
+export default class Authorizer {
+  constructor(cfg) {
+    this. authorizers = cfg.app.authorizers.map((name) => {
+      return new (require('./authz/' + name))({cfg});
+    });
+  }
+
+  async setup() {
+    await Promise.all(this.authorizers.map(authz => authz.setup()));
+  }
+
+  /**
+   * Authorize the given user, calling user.addRole for all roles
+   * linked to user.identity.
+   */
+  async authorize(user) {
+    /* invoke all authorizers which recognize this identityProviderId */
+    return Promise.all(this.authorizers.map(authz => {
+      if (authz.identityProviders.indexOf(user.identityProviderId) !== -1) {
+        return authz.authorize(user)
+      }
+    }));
+  }
+
+  /**
+   * A list of identity providers for which this authorizer is responsible
+   */
+  get identityProviders() {
+    return this.authorizers
+      .map(authz => authz.identityProviders)
+      .reduce((a,b) => a.concat(b));
+  }
+}

--- a/src/persona.js
+++ b/src/persona.js
@@ -1,0 +1,42 @@
+var browserIdVerify = require('browserid-verify');
+
+class PersonaError extends Error {
+  constructor(message) {
+    super();
+    this.code = "PersonaError";
+    this.message = message;
+  }
+}
+
+class PersonaVerifier {
+  constructor(options) {
+    this.allowedAudiences = options.allowedAudiences || [];
+    this.verifier = browserIdVerify();
+  }
+
+  /**
+   * Invoke the BrowserID verifier, returning a promise that will fire with the
+   * verified email address.  Persona exceptions will include `code:
+   * "PersonaError'`.
+   */
+  verify(assertion, audience) {
+    return new Promise((resolve, reject) => {
+      if (this.allowedAudiences.indexOf(audience) === -1) {
+        throw new PersonaError("audience not allowed");
+      }
+      this.verifier(assertion, audience, (err, email, response) => {
+        if (err) {
+          reject(err);
+        } else if (response.status == "failure") {
+          reject(new PersonaError(response.reason));
+        } else if (!email) {
+          reject(new PersonaError("no email returned"));
+        } else {
+          resolve(email);
+        }
+      });
+    });
+  }
+}
+
+module.exports = PersonaVerifier;

--- a/src/user.js
+++ b/src/user.js
@@ -29,6 +29,7 @@ export default class User {
   }
 
   addRole(role) {
+    assert(this._identity !== undefined);
     if (this.roles.indexOf(role) === -1) {
       this.roles.push(role);
     }

--- a/test/api_test.js
+++ b/test/api_test.js
@@ -10,7 +10,35 @@ suite('API', function() {
 
   suite("ping", function() {
     test("pings", async () => {
-        await helper.login.ping();
+      await helper.login.ping();
+    });
+  });
+
+  suite("persona", function() {
+    test("generates credentials", async () => {
+      let creds = await helper.login.credentialsFromPersonaAssertion({
+        assertion: "abcd",
+        audience: 'https://tools.taskcluster.net:443',
+      });
+      let cert = JSON.parse(creds.certificate);
+      // check that the fake authorizer authorized the user that the fake verifier verified
+      assume(helper.authorizer.identitiesSeen).to.contain('persona/nobody@persona.org');
+      assume(cert.scopes).to.contain("assume:fake-authorizer:nobody@persona.org");
+    });
+
+    test("fails with 400 for a PersonaError", async () => {
+      helper.personaVerifier.error = new Error("oh noes");
+      helper.personaVerifier.error.code = "PersonaError";
+      try {
+        await helper.login.credentialsFromPersonaAssertion({
+          assertion: "abcd",
+          audience: 'https://tools.taskcluster.net:443',
+        });
+      } catch(err) {
+        assume(err.statusCode).to.equal(400);
+        return;
+      }
+      throw new Error("unexpected success");
     });
   });
 });

--- a/test/helper.js
+++ b/test/helper.js
@@ -1,4 +1,5 @@
 var taskcluster = require('taskcluster-client');
+var assume      = require('assume');
 var testing     = require('taskcluster-lib-testing');
 var v1          = require('../lib/v1');
 var load        = require('../lib/server');
@@ -9,12 +10,48 @@ var cfg = config({profile: 'test'});
 
 var helper = module.exports = {};
 
-helper.loadOptions = {profile: 'test', process: 'test-helper'};
+class FakeAuthorizer {
+  async authorize(user) {
+    this.identitiesSeen.push(user.identity);
+    user.addRole('fake-authorizer:' + user.identityId);
+  }
+
+  get identityProviders() {
+    return ['fake-authorizer'];
+  }
+}
+
+class FakePersonaVerifier {
+  constructor() {
+    this.error = null;
+    this.expectedAssertion = "abcd";
+    this.expectedAudience = "https://tools.taskcluster.net:443";
+  }
+
+  async verify(assertion, audience) {
+    assume(assertion).to.equal(this.expectedAssertion);
+    assume(audience).to.equal(this.expectedAudience);
+    if (this.error) {
+      throw this.error;
+    }
+    return "nobody@persona.org";
+  }
+}
 
 // Call this in suites or tests that make API calls, etc; it will set up
 // what's required to respond to those calls.
-helper.setup = function() {
+helper.setup = function(options) {
+  options = options || {};
   var webServer = null;
+
+  helper.authorizer = new FakeAuthorizer();
+  helper.personaVerifier = new FakePersonaVerifier();
+  var loadOptions = {
+    profile: 'test',
+    process: 'test-helper',
+    authorizer: helper.authorizer,
+    personaVerifier: helper.personaVerifier,
+  };
 
   // Setup before tests
   suiteSetup(async () => {
@@ -24,7 +61,7 @@ helper.setup = function() {
 
     webServer = await load('server', _.defaults({
       authenticators: [],
-    }, helper.loadOptions));
+    }, loadOptions));
 
     // Create client for working with API
     helper.baseUrl = 'http://localhost:' + webServer.address().port + '/v1';
@@ -41,7 +78,6 @@ helper.setup = function() {
           clientId:       'test-client',
           accessToken:    'none'
         },
-        //authBaseUrl: cfg.get('taskcluster:authBaseUrl'),
         authorizedScopes: (scopes.length > 0 ? scopes : undefined)
       });
     };
@@ -49,6 +85,7 @@ helper.setup = function() {
 
   // Setup before each test
   setup(async () => {
+    helper.authorizer.identitiesSeen = [];
     // Setup client with all scopes
     helper.scopes();
   });

--- a/test/persona_test.js
+++ b/test/persona_test.js
@@ -1,0 +1,59 @@
+import 'mocha'
+import assume from 'assume'
+import PersonaVerifier from '../lib/persona';
+
+suite('persona', function() {
+  let personaVerifier = new PersonaVerifier({allowedAudiences: ['audie']});
+
+  test("returns email on success", async function() {
+    personaVerifier.verifier = (assertion, audience, cb) => {
+      assume(assertion).to.equal("abcd");
+      assume(audience).to.equal("audie");
+      cb(null, "nobody@persona.org", {'status': 'okay'});
+    }
+    assume(await personaVerifier.verify("abcd", "audie")).to.equal('nobody@persona.org');
+  });
+
+  test("throws error on failure", async function() {
+    personaVerifier.verifier = (assertion, audience, cb) => {
+      assume(assertion).to.equal("abcd");
+      assume(audience).to.equal("audie");
+      cb(null, undefined, {'status': 'failure', 'reason': 'uh oh'});
+    }
+    try {
+      await personaVerifier.verify("abcd", "audie");
+    } catch(err) {
+      assume(err.message).to.equal('uh oh');
+      return;
+    }
+    throw new Error("unexpected success");
+  });
+
+  test("rethrows errors", async function() {
+    personaVerifier.verifier = (assertion, audience, cb) => {
+      assume(assertion).to.equal("abcd");
+      assume(audience).to.equal("audie");
+      cb(new Error("uhoh"));
+    }
+    try {
+      await personaVerifier.verify("abcd", "audie");
+    } catch(err) {
+      assume(err.message).to.equal('uhoh');
+      return;
+    }
+    throw new Error("unexpected success");
+  });
+
+  test("fails if audience is not whitelisted", async function() {
+    personaVerifier.verifier = (assertion, audience, cb) => {
+      cb(new Error("should not get here"));
+    }
+    try {
+      await personaVerifier.verify("abcd", "not-audie");
+    } catch(err) {
+      assume(err.message).to.equal('audience not allowed');
+      return;
+    }
+    throw new Error("unexpected success");
+  });
+});


### PR DESCRIPTION
This required some refactoring of the authorization stuff, but the idea is that this can be used to turn a Persona assertion (gathered by the tools UI) into temporary credentials.  Once the similar method for SAML assertions is complete, and once the tools UI has been updated to use it, I'll remove all of the UI support in login and it will just be an API service.  At that point, federated logins will all go to the tools site.