### PR TITLE
Bug 1256249: support direct SSO authentication

### DIFF
--- a/src/authn/sso.js
+++ b/src/authn/sso.js
@@ -14,6 +14,7 @@ class SSOLogin {
     assert(options.cfg.sso.certificate, 'options.cfg.sso.certificate is required');
     assert(options.authorize, 'options.authorize is required');
 
+    this.cfg = options.cfg;
     this.authorize = options.authorize;
 
     passport.use(new saml.Strategy({
@@ -28,11 +29,70 @@ class SSOLogin {
 
   router() {
     let router = new express.Router();
+
+    /* This is a bit tangled.  There's the "old way" and the "new way" and
+     * they all use /login.  There is an ultimate goal, so this tangled mess
+     * won't live forever.
+     *
+     * Old:
+     *   Clicking "Sign-In With Okta" on the *login* site POSTS to /login
+     *   Passport redirects to Okta
+     *   Okta POSTs back to /login
+     *   samlCallback, below, creates a User object and makes a cookie
+     *   Passport redirects to /
+     *   The HTML at / sees that the requester was tools, and redirects
+     *     there via window.location
+     *
+     * New:
+     *   Clicking "Sign-In with Okta" on the *tools* site links to GET /login
+     *   That route sets a cookie to indicate the new way and redirects to
+     *      the Okta endpoint
+     *   Okta POSTs back to /login
+     *   Handler sees the new-way cookie, clears it, and redirects back to tools
+     *
+     * Ultimate Goal:
+     *   Clicking "Sign-In with Okta" on the *tools* site links to GET /login
+     *   That route redirects to Okta
+     *   Okta POSTS to /login
+     *   That processes the SAML and redirects (success or failure) to tools
+     */
+
+    // the form on the login landing page POSTs, and the SSO service
+    // POSTs back here
     router.post('/login', passport.authenticate('saml', {
-      successRedirect: '/',
+      // NOTE: Okta handles most errors internally -- I don't know how to reproduce
+      // this failureRedirect
       failureRedirect: '/',
       failureFlash: true
-    }));
+    }), (req, res) => {
+      if (!req.session['new-way']) {
+        res.redirect('/');
+        return;
+      }
+
+      // only do this once..
+      delete req.session['new-way'];
+
+      // generate temporary credentials and send them back to tools in a URL query
+      let credentials = req.user.createCredentials(this.cfg.app.temporaryCredentials);
+      var querystring = [];
+      querystring.push('clientId=' + encodeURIComponent(credentials.clientId));
+      querystring.push('accessToken=' + encodeURIComponent(credentials.accessToken));
+      querystring.push('certificate=' + encodeURIComponent(credentials.certificate));
+      querystring = querystring.join('&');
+
+      let url = `https://tools.taskcluster.net/login/?${querystring}`;
+      res.redirect(url)
+    });
+
+    // but tc-tools sends the browser to GET this URL
+    router.get('/login', (req, res) => {
+      // redirect to the login URL.  This will eventually POST back to
+      // the /login route, above, which 
+      req.session['new-way'] = 1;
+      res.redirect(this.cfg.sso.entryPoint);
+    });
+
     return router;
   };
 


### PR DESCRIPTION
This is a transitional arrangement, built to still support the old way
and the new way at the same time.  But the new way does not involve any
UI from the login site, which is the key goal here.