### PR TITLE
Use Auth0 Passwordless with the redirect flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Supported authentication systems:
  * Persona - A very basic verification that the user owns an email address.
    User identities are of the form `persona/<email>`.
  * Passwordless - Similar to persona, but not deprecated.  User identities are
- * of the form `email/<email>`.
+   of the form `email/<email>`.
 
 Supported authorization systems:
  * LDAP - Translates LDAP groups (including POSIX groups) to TaskCluster roles

--- a/src/authn/auth0.js
+++ b/src/authn/auth0.js
@@ -29,10 +29,14 @@ class Auth0Login {
   router() {
     let router = new express.Router();
 
-    console.log('setting up auth0/login');
-    router.get('/login', passport.authenticate('auth0', {
-      failureRedirect: '/',
-      failureFlash: true
+    // render the Jade template that shows the lock on get
+    router.get('/login', (req, res) => {
+      res.render('auth0', {
+        auth0_domain: this.cfg.auth0.domain,
+        auth0_client_id: this.cfg.auth0.clientId,
+      });
+    });
+    router.get('/callback', passport.authenticate('auth0', {
     }), (req, res) => {
       res.redirect('/');
       return;
@@ -45,7 +49,6 @@ class Auth0Login {
   auth0Callback(accessToken, refreshToken, extraParams, profile, done) {
     try {
       let user = new User();
-      console.log(profile._json);
       if (!profile._json.email_verified) {
         throw new Error('email is not verified');
       }

--- a/views/auth0.jade
+++ b/views/auth0.jade
@@ -1,0 +1,16 @@
+doctype html
+html(lang='en')
+  head
+    meta(charset='utf-8')
+    title TaskCluster Login
+    meta(name='viewport', content='width=device-width, initial-scale=1.0')
+
+    // Auth0 passwordless lock - https://github.com/auth0/lock-passwordless
+    script(src="//cdn.auth0.com/js/lock-passwordless-2.2.3.min.js")
+  body
+    script.
+      var lock = new Auth0LockPasswordless('#{auth0_client_id}', '#{auth0_domain}');
+      lock.emailcode({
+        closable: false,
+        callbackURL: window.location.origin + '/auth0/callback',
+      });

--- a/views/index.jade
+++ b/views/index.jade
@@ -21,10 +21,6 @@ html(lang='en')
     // Persona login script
     script(src='https://login.persona.org/include.js')
 
-    if query.auth0
-      // Auth0 passwordless lock - https://github.com/auth0/lock-passwordless
-      script(src="//cdn.auth0.com/js/lock-passwordless-2.2.3.min.js")
-
     // Marked for rendering markdown
     script(src='/assets/marked.min.js')
 
@@ -33,18 +29,6 @@ html(lang='en')
 
     // Script with various hacks for this page
     script(src='/assets/script.js')
-    if query.auth0
-      script.
-        var lock = new Auth0LockPasswordless('#{auth0_client_id}', '#{auth0_domain}');
-        $(function() {
-          $('#auth0-form').submit(function(e) {
-            e.preventDefault();
-            lock.emailcode({
-              closable: false,
-              callbackURL: window.location.origin + '/auth0/login',
-            });
-          });
-        });
   body.container
     div.modal#manual-modal(tabindex="-1", role="dialog")
       div.modal-dialog.modal-open
@@ -95,7 +79,7 @@ html(lang='en')
         if query.auth0
           div.row.login-option
             div.col-md-4
-              form#auth0-form(method='post')
+              form#auth0-form(action='/auth0/login', method='get')
                 button.btn.btn-block.btn-primary(type='submit')
                   i.glyphicon.glyphicon-user
                   | &nbsp;Passwordless Sign-In


### PR DESCRIPTION
This is basically the only functional option right now.  Auth begins
with a GET to /auth0/login, which shows the passwordless lock (neither
the passwordful lock nor the mozilla lock work, and passwordless lock
doesn't work when embedded in a React application).  On submit, that
redirects to /auth0/callback with the necessary tokens, and that
endpoint translates those into a User object, which is used to generate
credentials as usual (by redirecting to /).

@gdestuynder FYI