### PR TITLE
Automatically go to tools after auth0, unless user clicked locally

### DIFF
--- a/views/index.jade
+++ b/views/index.jade
@@ -79,7 +79,7 @@ html(lang='en')
         if query.auth0
           div.row.login-option
             div.col-md-4
-              form#auth0-form(action='/auth0/login', method='get')
+              form#auth0-form(action='/auth0/login-local', method='get')
                 button.btn.btn-block.btn-primary(type='submit')
                   i.glyphicon.glyphicon-user
                   | &nbsp;Passwordless Sign-In


### PR DESCRIPTION
This duplicates the functionality of the "new-style" Okta logins.

In fact, it copies a bunch of code.  I'm not too worried, since pretty much all of this will be completely refactored soon.  Basically, all logins will be via Auth0 (getting rid of Okta) and we will redirect federated logins either to auth0 or to the tools site, so there will be no need for a local "old way".  That all depends on how auth0 evolves, though.