### PR TITLE
":443" port is no needed for mozilla-releng.net when listing TRUSTED_TARGETS

### DIFF
--- a/assets/script.js
+++ b/assets/script.js
@@ -33,10 +33,10 @@ var TRUSTED_TARGETS = [
   'https://tools.taskcluster.net/login/',
   'https://treeherder.allizom.org:443/#/login',
   'https://treeherder.mozilla.org:443/#/login',
-  'https://mozilla-releng.net:443/login',
-  'https://staging.mozilla-releng.net:443/login',
-  'https://shipit.mozilla-releng.net:443/login',
-  'https://shipit.staging.mozilla-releng.net:443/login'
+  'https://mozilla-releng.net/login',
+  'https://staging.mozilla-releng.net/login',
+  'https://shipit.mozilla-releng.net/login',
+  'https://shipit.staging.mozilla-releng.net/login'
 ];
 
 // Okay, this isn't pretty... But we have to store the stuff we got from the


### PR DESCRIPTION
For some reason, I thought, you need to provide a port number.