### PR TITLE
Bug 1388541: return an expiration for credentials

### DIFF
--- a/docs/getting-user-creds.md
+++ b/docs/getting-user-creds.md
@@ -48,11 +48,15 @@ application.
 ## Getting Credentials
 
 Your application should defer getting Taskcluster credentials until they are
-needed, and should support automatically re-fetching credentials and re-trying
-a request when they expire (identified by a 401 response from a Taskcluster
-API).
+needed, and should support automatically refreshing expired credentials as
+needed. The credentials may expire before the `access_token` or `id_token`.
 
 To get credentials, call the [`oidcCredentials`
 endpoint](/reference/integrations/taskcluster-login/references/api#oidcCredentials)
 with provider `mozilla-auth0`.  Pass the `access_token` from Auth0 in the
 `Authorization` header as described in the API documentation.
+
+Note that the returned credentials may or may not contain a `certificate`
+field. Be sure that any code handling credentials is compatible with either
+result. As always, callers should not interpret the resulting credentials in
+any way, although displaying the clientId to the user is acceptable.

--- a/schemas/oidc-credentials-response.yml
+++ b/schemas/oidc-credentials-response.yml
@@ -1,0 +1,30 @@
+$schema:                  http://json-schema.org/draft-04/schema#
+title:                    "Credentials Response"
+description: |
+  A response containing credentials corresponding to a supplied OIDC `access_token`.
+type: object
+properties:
+  expires:
+    description: |
+      Time after which the credentials are no longer valid.  Callers should
+      call `oidcCredentials` again to get fresh credentials before this time.
+    type:                     string
+    format:                   date-time
+  credentials:
+    type:                     object
+    description: |
+      Taskcluster credentials. Note that the credentials may not contain a certificate!
+    title:                    Taskcluster Credentials
+    properties:
+      clientId:
+        type:                 string
+        pattern:              {$const: clientId}
+      accessToken:
+        type:                 string
+        pattern:              {$const:  access-token-pattern}
+      certificate:
+        type:                 string
+    additionalProperties:     false
+    required:
+      - clientId
+      - accessToken

--- a/src/authn/auth0.js
+++ b/src/authn/auth0.js
@@ -59,7 +59,7 @@ class Auth0Login {
       delete req.session['auth0-local'];
 
       // generate temporary credentials and send them back to tools in a URL query
-      let credentials = req.user.createCredentials(this.cfg.app.temporaryCredentials);
+      let {credentials} = req.user.createCredentials(this.cfg.app.temporaryCredentials);
       var querystring = [];
       querystring.push('clientId=' + encodeURIComponent(credentials.clientId));
       querystring.push('accessToken=' + encodeURIComponent(credentials.accessToken));

--- a/src/authn/sso.js
+++ b/src/authn/sso.js
@@ -74,7 +74,7 @@ class SSOLogin {
       delete req.session['new-way'];
 
       // generate temporary credentials and send them back to tools in a URL query
-      let credentials = req.user.createCredentials(this.cfg.app.temporaryCredentials);
+      let {credentials} = req.user.createCredentials(this.cfg.app.temporaryCredentials);
       var querystring = [];
       querystring.push('clientId=' + encodeURIComponent(credentials.clientId));
       querystring.push('accessToken=' + encodeURIComponent(credentials.accessToken));

--- a/src/server.js
+++ b/src/server.js
@@ -201,7 +201,7 @@ let load = loader({
       // Render index
       app.get('/', (req, res) => {
         let user = User.get(req);
-        let credentials = user.createCredentials(cfg.app.temporaryCredentials);
+        let {credentials} = user.createCredentials(cfg.app.temporaryCredentials);
         res.render('index', {
           user, credentials,
           querystring,

--- a/src/user.js
+++ b/src/user.js
@@ -51,13 +51,18 @@ export default class User {
     }
     let scopes = this.scopes();
 
-    return taskcluster.createTemporaryCredentials({
-      clientId: this.identity,
-      start: taskcluster.fromNow(options.startOffset),
-      expiry: taskcluster.fromNow(options.expiry),
-      scopes,
-      credentials: options.credentials
-    });
+    let expires = taskcluster.fromNow(options.expiry);
+
+    return {
+      expires,
+      credentials: taskcluster.createTemporaryCredentials({
+        clientId: this.identity,
+        start: taskcluster.fromNow(options.startOffset),
+        expiry: expires,
+        scopes,
+        credentials: options.credentials,
+      }),
+    };
   }
 
   /** Serialize user to JSON */

--- a/test/api_test.js
+++ b/test/api_test.js
@@ -25,8 +25,11 @@ suite('API', function() {
       let res = await request
         .get(helper.baseUrl + '/oidc-credentials/test')
         .set('Authorization', 'Bearer let-me-in');
-      let creds = JSON.parse(res.text);
-      assume(creds.clientId).to.equal('test/let-me-in');
+      let resp = JSON.parse(res.text);
+      assume(resp.credentials.clientId).to.equal('test/let-me-in');
+      let until_exp = new Date(resp.expires) - new Date();
+      console.log(until_exp);
+      assume(until_exp).greaterThan(14 * 60 * 1000);
     });
 
   });


### PR DESCRIPTION
This allows users to know when the credentials need to be refreshed,
without trying to do tricky things to parse the credentials.

@eliperelman this will require a change in the demo (to look for res.credentials, and additionally to handle refreshing after expiration).