### PR TITLE
Bug 1388548 - set short expiration on credentials from oidcCredentials

### DIFF
--- a/src/handlers/mozilla-auth0.js
+++ b/src/handlers/mozilla-auth0.js
@@ -98,6 +98,7 @@ class Handler {
 
     let user = new User();
     user.identity = 'mozilla-auth0/' + profile.email;
+    user.expires = new Date(req.user.exp * 1000);
 
     // TODO: add scopes based on profile; waiting on profile rollout and documentation
 

--- a/src/user.js
+++ b/src/user.js
@@ -51,7 +51,11 @@ export default class User {
     }
     let scopes = this.scopes();
 
+    // take the soonest expiry
     let expires = taskcluster.fromNow(options.expiry);
+    if (this.expires && this.expires < expires) {
+      expires = this.expires;
+    }
 
     return {
       expires,


### PR DESCRIPTION
https://wiki.mozilla.org/Security/Guidelines/OpenID_connect suggests
that callers re-check tokens every 15 minutes to gather any changes to
the user account. With this change, we force clients of
Taskcluster-login to do the same.