### PR TITLE
Bug 1395320 - stop enumerating posix groups

### DIFF
--- a/src/authz/ldap.js
+++ b/src/authz/ldap.js
@@ -74,21 +74,9 @@ class LDAPAuthorizer {
     };
 
     await this.client.operate(async (client) => {
-      debug(`enumerating scm groups for ${email}`);
       // always perform a bind, in case the client has disconnected
       // since this connection was last used.
       await client.bind(this.user, this.password);
-
-      // SCM groups are posixGroup objects with the email in the memberUid
-      // field.  This code does not capture other POSIX groups (which have the
-      // user's uid field in the memberUid field).
-      addRolesForEntries(await client.search(
-        'dc=mozilla', {
-          scope: 'sub',
-          filter: '(&(objectClass=posixGroup)(memberUid=' + email + '))',
-          attributes: ['cn'],
-          timeLimit: 10,
-        }));
 
       let userDn = await client.dnForEmail(email);
       if (!userDn) {


### PR DESCRIPTION
Historically, SCM access has been controlled by "posixGroup" objects,
which are different LDAP things from "groupOfNames" groups.  Now,
however, SCM access is available in regular LDAP groupOfNames groups.
Even better, that's divided into active and inactive -- and we only want
*active* people to have access.

The roles have already been set up to support this, so the old
posixGroup support is no longer required.