### PR TITLE
Add SHOW_AUTH0 config (temporary)

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -1,4 +1,5 @@
 Defaults:
+  showAuth0:          !env:bool SHOW_AUTH0
   app:
     authenticators:
       - auth0

--- a/src/authn/auth0.js
+++ b/src/authn/auth0.js
@@ -46,6 +46,12 @@ class Auth0Login {
       });
     });
 
+    // similarly, but use the hosted lock to temporarily allow LDAP
+    router.get('/login-temp', (req, res) => {
+      req.session['auth0-local'] = 1;
+      res.redirect('/auth0/callback');
+    });
+
     // this path will either handle a callback from the lock in the Jade
     // template, or a callback from the hosted lock (allowing LDAP login).  In
     // either case, req.user has been set up already.

--- a/src/server.js
+++ b/src/server.js
@@ -196,6 +196,7 @@ let load = loader({
           session: req.session,
           auth0_domain: cfg.auth0.domain,
           auth0_client_id: cfg.auth0.clientId,
+          showAuth0: cfg.showAuth0,
         });
       });
 

--- a/views/index.jade
+++ b/views/index.jade
@@ -59,6 +59,18 @@ html(lang='en')
         hr
         p
           | Choose the best sign-in option for you from the options below.
+        if showAuth0
+          div.row.login-option
+            div.col-md-4
+              form(action='/auth0/login-temp', method='post')
+                button.btn.btn-block.btn-primary(type='submit')
+                  i.glyphicon.glyphicon-log-in
+                  | &nbsp;Sign-in with Auth0
+            div.col-md-8
+              p
+                | If you have a&nbsp;
+                b Mozilla LDAP Account
+                | , please try the Auth0 sign-in, as Okta will be disabled next week.
         div.row.login-option
           div.col-md-4
             form(action='/sso/login', method='post')


### PR DESCRIPTION
This also adds a redirect route that will set a session flag indicating
that this is a federated login and should not redirect back to tools.

This should allow us to enable stopgap federated login support.