### PR TITLE
Remove the Okta button, but not the backend support

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -1,5 +1,4 @@
 Defaults:
-  showAuth0:          !env:bool SHOW_AUTH0
   app:
     authenticators:
       - auth0

--- a/src/server.js
+++ b/src/server.js
@@ -196,7 +196,6 @@ let load = loader({
           session: req.session,
           auth0_domain: cfg.auth0.domain,
           auth0_client_id: cfg.auth0.clientId,
-          showAuth0: cfg.showAuth0,
         });
       });
 

--- a/views/index.jade
+++ b/views/index.jade
@@ -59,29 +59,17 @@ html(lang='en')
         hr
         p
           | Choose the best sign-in option for you from the options below.
-        if showAuth0
-          div.row.login-option
-            div.col-md-4
-              form(action='/auth0/login-temp', method='post')
-                button.btn.btn-block.btn-primary(type='submit')
-                  i.glyphicon.glyphicon-log-in
-                  | &nbsp;Sign-in with Auth0
-            div.col-md-8
-              p
-                | If you have a&nbsp;
-                b Mozilla LDAP Account
-                | , please try the Auth0 sign-in, as Okta will be disabled next week.
         div.row.login-option
           div.col-md-4
-            form(action='/sso/login', method='post')
+            form(action='/auth0/login-temp', method='post')
               button.btn.btn-block.btn-primary(type='submit')
                 i.glyphicon.glyphicon-log-in
-                | &nbsp;Sign-in with Okta
+                | &nbsp;Sign-in with Auth0
           div.col-md-8
             p
               | If you have a&nbsp;
               b Mozilla LDAP Account
-              | , sign in with Okta to maximize your
+              | , sign in with Auth0 to maximize your
               | permissions.  You can use this option even if you are not an employee!
               | If you also have a Mozillians account, make sure your
               | LDAP email is included in your Mozillians profile.


### PR DESCRIPTION
The tools site is still using that backend support.