### PR TITLE
Modify role

### DIFF
--- a/src/handlers/mozilla-auth0.js
+++ b/src/handlers/mozilla-auth0.js
@@ -235,7 +235,7 @@ class Handler {
       }
     });
 
-    user.addRole(`mozilla-user:${user.identityId}`);
+    user.addRole(`login-identity:${user.identity}`);
     ldapGroups.forEach(group => user.addRole(`mozilla-group:${group}`));
 
     // add mozillians roles to everyone

--- a/src/handlers/mozilla-auth0.js
+++ b/src/handlers/mozilla-auth0.js
@@ -235,7 +235,6 @@ class Handler {
       }
     });
 
-    user.addRole(`login-identity:${user.identity}`);
     ldapGroups.forEach(group => user.addRole(`mozilla-group:${group}`));
 
     // add mozillians roles to everyone


### PR DESCRIPTION
Jonas suggests that we stop using any `mozilla-user:..` roles at all, and instead just use the `login-identity:..` roles we're already creating.

That would mean `login-idenitty:mozilla-auth0/ad|Mozilla-LDAP|foo` for every
`mozilla-user:foo@mozilla.com`  role. 