### PR TITLE
fix mozGroupPrefix handling

### DIFF
--- a/src/handlers/mozilla-auth0.js
+++ b/src/handlers/mozilla-auth0.js
@@ -219,7 +219,7 @@ class Handler {
 
     const mozGroupPrefix = 'mozilliansorg_';
     const hrisGroupPrefix = 'hris_';
-    const groups = (profile.app_metadata.groups || {}) || [];
+    const groups = (profile.app_metadata || {}).groups || [];
 
     // Non-prefixed groups are what is known as Mozilla LDAP groups. Groups prefixed by a provider
     // name and underscore are provided by a specific group engine. For example,

--- a/src/handlers/mozilla-auth0.js
+++ b/src/handlers/mozilla-auth0.js
@@ -225,24 +225,11 @@ class Handler {
     // name and underscore are provided by a specific group engine. For example,
     // `providername_groupone` is provided by `providername`. Per https://goo.gl/bwWjvE.
     // For our own purposes, if the prefix is not mozilliansorg. then we treat it as an ldap group
-    profile.groups && profile.groups.forEach(group => {
-      // capture mozillians groups
-      if (group.indexOf(mozGroupPrefix) === 0) {
-        mozGroups.push(group.replace(mozGroupPrefix, ''));
-      } else {
-        // treat everything else as ldap groups
-        ldapGroups.push(group);
-      }
-    });
+    const mozilliansGroups = (profile.groups || []).filter(g => g.startsWith(mozGroupPrefix)).map(g => g.slice(mozGroupPrefix.length));
+    const ldapGroups = (profile.groups || []).filter(g => !g.startsWith(mozGroupPrefix));
 
+    mozGroups.map(group => user.addRole(`mozillians-group:${group}`));
     ldapGroups.forEach(group => user.addRole(`mozilla-group:${group}`));
-
-    // add mozillians roles to everyone
-    mozGroups.map(group => {
-      const str = group.replace(mozGroupPrefix, '');
-
-      user.addRole(`mozillians-group:${str}`);
-    });
   }
 }
 

--- a/src/handlers/mozilla-auth0.js
+++ b/src/handlers/mozilla-auth0.js
@@ -216,9 +216,11 @@ class Handler {
   addRoles(profile, user) {
     // grant the everybody role to anyone who authenticates
     user.addRole('everybody');
-
+    console.log(JSON.stringify(profile));
     const mozGroupPrefix = 'mozilliansorg_';
-    const groups = profile.groups || [];
+    const groups = (profile.app_metadata.groups || {}) || [];
+
+
 
     // Non-prefixed groups are what is known as Mozilla LDAP groups. Groups prefixed by a provider
     // name and underscore are provided by a specific group engine. For example,

--- a/src/handlers/mozilla-auth0.js
+++ b/src/handlers/mozilla-auth0.js
@@ -216,11 +216,10 @@ class Handler {
   addRoles(profile, user) {
     // grant the everybody role to anyone who authenticates
     user.addRole('everybody');
-    console.log(JSON.stringify(profile));
+
     const mozGroupPrefix = 'mozilliansorg_';
+    const hrisGroupPrefix = 'hris_';
     const groups = (profile.app_metadata.groups || {}) || [];
-
-
 
     // Non-prefixed groups are what is known as Mozilla LDAP groups. Groups prefixed by a provider
     // name and underscore are provided by a specific group engine. For example,
@@ -228,11 +227,13 @@ class Handler {
     // For our own purposes, if the prefix is not mozilliansorg. then we treat it as an ldap group
     user.addRole(
       ...groups
+        .filter(g => !g.startsWith(hrisGroupPrefix))
         .filter(g => !g.startsWith(mozGroupPrefix))
         .map(g => `mozilla-group:${g}`)
     );
     user.addRole(
       ...groups
+        .filter(g => !g.startsWith(hrisGroupPrefix))
         .filter(g => g.startsWith(mozGroupPrefix))
         .map(g => g.slice(mozGroupPrefix.length))
         .map(g => `mozillians-group:${g}`)

--- a/src/handlers/mozilla-auth0.js
+++ b/src/handlers/mozilla-auth0.js
@@ -218,18 +218,23 @@ class Handler {
     user.addRole('everybody');
 
     const mozGroupPrefix = 'mozilliansorg_';
-    const mozGroups = [];
-    const ldapGroups = [];
+    const groups = profile.groups || [];
 
     // Non-prefixed groups are what is known as Mozilla LDAP groups. Groups prefixed by a provider
     // name and underscore are provided by a specific group engine. For example,
     // `providername_groupone` is provided by `providername`. Per https://goo.gl/bwWjvE.
     // For our own purposes, if the prefix is not mozilliansorg. then we treat it as an ldap group
-    const mozilliansGroups = (profile.groups || []).filter(g => g.startsWith(mozGroupPrefix)).map(g => g.slice(mozGroupPrefix.length));
-    const ldapGroups = (profile.groups || []).filter(g => !g.startsWith(mozGroupPrefix));
-
-    mozGroups.map(group => user.addRole(`mozillians-group:${group}`));
-    ldapGroups.forEach(group => user.addRole(`mozilla-group:${group}`));
+    user.addRole(
+      ...groups
+        .filter(g => !g.startsWith(mozGroupPrefix))
+        .map(g => `mozilla-group:${g}`)
+    );
+    user.addRole(
+      ...groups
+        .filter(g => g.startsWith(mozGroupPrefix))
+        .map(g => g.slice(mozGroupPrefix.length))
+        .map(g => `mozillians-group:${g}`)
+    );
   }
 }
 

--- a/src/user.js
+++ b/src/user.js
@@ -24,10 +24,12 @@ class User {
       .join('|');
   }
 
-  addRole(role) {
+  addRole(...roles) {
     assert(this._identity !== undefined);
-    if (this.roles.indexOf(role) === -1) {
-      this.roles.push(role);
+    for (const role of roles) {
+      if (!this.roles.includes(role)) {
+        this.roles.push(role);
+      }
     }
   }
 


### PR DESCRIPTION
This doesn't fix the bug we have where mozillians groups are missing...

But it does fix an obvious security issue (consider the case with a mozillians group named `taskcluster${mozGroupPrefix}-contributors`), and makes the code simpler...

**warning**, this is not tested... I don't think I have creds on my laptop. Consider this more of a bug report.