### PR TITLE
Activate the monitor for scanner, too

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -115,9 +115,14 @@ let load = loader({
   },
 
   scanner: {
-    requires: ['cfg', 'handlers'],
-    setup: async ({cfg, handlers}) => {
+    requires: ['cfg', 'handlers', 'monitor'],
+    setup: async ({cfg, handlers, monitor}) => {
       await scanner(cfg, handlers);
+
+      monitor.count('scanner.run');
+      monitor.stopResourceMonitoring();
+      await monitor.flush();
+
       // the LDAP connection is still open, so we must exit
       // explicitly or node will wait forever for it to die.
       process.exit(0);


### PR DESCRIPTION
This will catch unhandled exceptions, etc., which were previously visible only in logfiles.

..I think?