### PR TITLE
Bug 1511708 - add support for Firefox Accounts

### DIFF
--- a/src/handlers/mozilla-auth0.js
+++ b/src/handlers/mozilla-auth0.js
@@ -160,10 +160,8 @@ class Handler {
 
     let encodedUserId = identity.split('/')[1];
 
-    // Reverse the github username appending, stripping the username.  Note
-    // that github says, "Username may only contain alphanumeric characters or
-    // single hyphens, and cannot begin or end with a hyphen"
-    if (encodedUserId.startsWith('github|')) {
+    // Reverse the username appending, stripping the username.
+    if (encodedUserId.startsWith('github|') || encodedUserId.startsWith('firefoxaccounts|')) {
       encodedUserId = encodedUserId.replace(/\|[^|]*$/, '');
     }
 
@@ -184,10 +182,13 @@ class Handler {
       ) {
         assert(!profile.user_id.startsWith('github|'));
         identity = `${this.identityProviderId}/${encode(profile.user_id)}`;
+      // we annotate some userids with `|nickname` since otherwise the userid
+      // is just numeric and difficult for humans to interpret
       } else if (provider === 'github' && connection === 'github') {
-        // we annotate github userids with `|nickname` since otherwise the userid is just numeric
-        // and difficult for humans to interpret
         assert(profile.user_id.startsWith('github|'));
+        identity = `${this.identityProviderId}/${encode(profile.user_id)}|${profile.nickname}`;
+      } else if (provider === 'oauth2' && connection === 'firefoxaccounts') {
+        assert(profile.user_id.startsWith('firefoxaccounts|'));
         identity = `${this.identityProviderId}/${encode(profile.user_id)}|${profile.nickname}`;
       }
     });

--- a/test/handlers_mozilla_auth0_test.js
+++ b/test/handlers_mozilla_auth0_test.js
@@ -51,6 +51,12 @@ suite('handlers/mozilla-auth0', function() {
       identity: 'mozilla-auth0/github|1234|helfi92',
     });
 
+    testClientId('firefoxaccounts clientId', {
+      clientId: 'mozilla-auth0/firefoxaccounts|abcdef|djmitche/',
+      userId: 'firefoxaccounts|abcdef',
+      identity: 'mozilla-auth0/firefoxaccounts|abcdef|djmitche',
+    });
+
     testClientId('encoded clientId', {
       clientId: 'mozilla-auth0/email|slashy!2Fslashy/abc',
       userId: 'email|slashy/slashy',
@@ -88,6 +94,15 @@ suite('handlers/mozilla-auth0', function() {
         identities: [{provider: 'github', connection: 'github'}],
       },
       identity: 'mozilla-auth0/github|1234|helfi92',
+    });
+
+    testProfile('firefoxaccounts profile', {
+      profile: {
+        nickname: 'fxsync',
+        user_id: 'firefoxaccounts|01290ca01be',
+        identities: [{provider: 'oauth2', connection: 'firefoxaccounts'}],
+      },
+      identity: 'mozilla-auth0/firefoxaccounts|01290ca01be|fxsync',
     });
 
     test('userIdFromClientId with non-matching clientId', function() {


### PR DESCRIPTION
This is modeled after the Github support: no groups specific to this
login modality, and append the nickname to each account for
human disambiguation.

I have based this on my Firefox sync account (which uses a throwaway email address not equal to any of my others, since the sync accounts tied to all of my regular accounts got corrupted) with the profile I pasted in the bug.  I'm not sure what happens when such a user is in a Mozillians group, but I'm hoping it appears in the profile.  If that's not the case, then that's a ParSys bug..